### PR TITLE
conductor-mac: permit urn:andy-issues-api resource scope

### DIFF
--- a/src/Andy.Auth.Server/Data/DbSeeder.cs
+++ b/src/Andy.Auth.Server/Data/DbSeeder.cs
@@ -895,6 +895,13 @@ public class DbSeeder
                 OpenIddictConstants.Permissions.Prefixes.Scope + "offline_access",
                 "scp:urn:andy-docs-api",
                 "scp:urn:andy-code-index-api",
+                // conductor-mac talks to andy-issues (backlog import,
+                // repo registry, etc.); without this permission the
+                // JWT emitted for Conductor has aud=[docs, code-index]
+                // only, and andy-issues' JwtBearer middleware rejects
+                // every request with IDX10214 audience mismatch. See
+                // rivoli-ai/conductor#545 for the broader sweep.
+                "scp:urn:andy-issues-api",
 
                 OpenIddictConstants.Permissions.ResponseTypes.Code
             },


### PR DESCRIPTION
## Problem

The \`conductor-mac\` OpenIddict client can't request tokens with \`urn:andy-issues-api\` in the \`aud\` claim — the scope permission isn't in its \`Permissions\` list. That means every request from Conductor to the embedded \`andy-issues\` service fails JwtBearer audience validation:

\`\`\`
IDX10214: Audience validation failed.
Audiences: 'urn:andy-docs-api, urn:andy-code-index-api'.
Did not match: validationParameters.ValidAudience: 'urn:andy-issues-api'
\`\`\`

In dev mode \`andy-issues\` has an \"allow any\" authorization policy, so the request proceeds anyway — but the \`ClaimsPrincipal\` is anonymous. The controller's \`GetUserId()\` falls back to the literal string \`\"dev-user\"\` and writes rows under a phantom identity.

## Fix

Add \`\"scp:urn:andy-issues-api\"\` to \`conductor-mac\`'s permissions. The scope resource is already registered (\`DbSeeder.cs:133-146\`) — just the client-side permission was missing.

\`DbSeeder\` uses delete-and-recreate for this client, so existing dev databases pick up the new permission on next startup with no manual migration.

## Context

Part of [rivoli-ai/conductor#545](https://github.com/rivoli-ai/conductor/issues/545) — full sweep still needed for every other andy-* service Conductor calls.

Paired conductor-side PR adds \`urn:andy-issues-api\` to \`DevAutoSignIn.scopes\`.

## Test plan

- [x] \`dotnet build\` clean.
- [ ] After merge + conductor paired PR + embedded binary rebuild: Conductor → andy-issues request shows \`Bearer was successfully authenticated\` (no IDX10214), new rows land under the real test@andy.local user id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)