### PR TITLE
conductor-mac: permit urn:andy-containers-api and andy-rbac scopes

### DIFF
--- a/src/Andy.Auth.Server/Data/DbSeeder.cs
+++ b/src/Andy.Auth.Server/Data/DbSeeder.cs
@@ -902,6 +902,14 @@ public class DbSeeder
                 // every request with IDX10214 audience mismatch. See
                 // rivoli-ai/conductor#545 for the broader sweep.
                 "scp:urn:andy-issues-api",
+                // Conductor also talks directly to andy-containers
+                // (sandbox provisioning, template catalog) and andy-rbac
+                // (org membership checks). Without these, the same
+                // IDX10214 audience mismatch hits those services and
+                // their ClaimsPrincipal stays anonymous. Part of the
+                // conductor#545 sweep.
+                "scp:urn:andy-containers-api",
+                "scp:andy-rbac",
 
                 OpenIddictConstants.Permissions.ResponseTypes.Code
             },


### PR DESCRIPTION
Follow-up to 15871c7. Adds the next two conductor-mac permissions on the follow-up list in that commit's message.

## What

- `scp:urn:andy-containers-api`
- `scp:andy-rbac`

## Why

Without these permissions, OpenIddict drops the requested scopes and the JWT's `aud` claim lacks the target audience. The target service's `JwtBearer` middleware rejects every request with `IDX10214` and the `ClaimsPrincipal` stays anonymous on the resource server.

andy-issues' [#65](https://github.com/rivoli-ai/andy-issues/issues/65) (`"dev-user"` fallback) is the best-documented symptom; andy-containers and andy-rbac share the same failure mode. andy-issues has already removed its silent fallback (andy-issues#86), so requests against it will now 401 loudly when the audience is missing — making this problem immediately visible for the other services too.

## Scope trimming

15871c7's message listed the full follow-up sweep as "rbac, containers, subscription, mcp-gateway, settings, narration". This PR narrows to the two Conductor actually talks to today and that already have registered scopes in this seeder:

| Service | Conductor calls it? | Scope registered? | Included |
|---|---|---|---|
| containers | ✓ (`ContainersServiceConfig.swift`) | `urn:andy-containers-api` | ✓ |
| rbac | ✓ (`RbacServiceConfig.swift`) | `andy-rbac` | ✓ |
| subscription | ✗ (not in `Conductor/Core/ServiceHost/Services/`) | `urn:andy-subscription-api` | — |
| narration | ✗ | `urn:andy-narration-api` | — |
| mcp-gateway | ✓ (`McpGatewayServiceConfig.swift`) | ✗ no scope registered | deferred |
| settings | — | ✗ no scope registered | deferred |

mcp-gateway and settings need their resource scopes registered in this seeder first; that's a separate PR per service.

## Companion PR

Granting the permission here is necessary but **not sufficient** until Conductor requests the scope. A companion PR to `rivoli-ai/conductor` updates `DevAutoSignIn.scopes` accordingly.

## Test plan

- [x] `dotnet build` — green, 0 errors (pre-existing warnings unchanged)
- [x] `dotnet test` — 25 pre-existing failures unchanged (verified by `git stash` / re-run)
- [x] Change is purely additive to an array literal; no behavior change for any existing permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)