### PR TITLE
Sync CORS allow-list to the full client registry (three modes)

### DIFF
--- a/src/Andy.Auth.Server/appsettings.Development.json
+++ b/src/Andy.Auth.Server/appsettings.Development.json
@@ -9,20 +9,25 @@
       "Microsoft.EntityFrameworkCore": "Information"
     }
   },
+  "//CorsOrigins": "Every Andy Angular client origin across dotnet + docker modes. See andy-service-template/docs/ports.md. Update in lockstep with that registry.",
   "CorsOrigins": {
     "AllowedOrigins": [
-      "http://localhost:4200",
-      "https://localhost:4200",
-      "http://localhost:4201",
-      "https://localhost:4201",
-      "http://localhost:5180",
-      "https://localhost:5180",
-      "http://localhost:5181",
-      "https://localhost:5181",
-      "http://localhost:4202",
-      "https://localhost:4202",
-      "http://localhost:5320",
-      "https://localhost:5320"
+      "http://localhost:4200",  "https://localhost:4200",
+      "http://localhost:4201",  "https://localhost:4201",
+      "http://localhost:4202",  "https://localhost:4202",
+      "http://localhost:4203",  "https://localhost:4203",
+      "http://localhost:4204",  "https://localhost:4204",
+      "http://localhost:4205",  "https://localhost:4205",
+      "http://localhost:6200",  "https://localhost:6200",
+      "http://localhost:6201",  "https://localhost:6201",
+      "http://localhost:6202",  "https://localhost:6202",
+      "http://localhost:6203",  "https://localhost:6203",
+      "http://localhost:6204",  "https://localhost:6204",
+      "http://localhost:6205",  "https://localhost:6205",
+      "http://localhost:9100",
+      "http://localhost:5180",  "https://localhost:5180",
+      "http://localhost:5181",  "https://localhost:5181",
+      "http://localhost:5320",  "https://localhost:5320"
     ]
   },
   "OpenIddict": {


### PR DESCRIPTION
## Summary

Brings \`appsettings.Development.json → CorsOrigins:AllowedOrigins\` in line with \`andy-service-template/docs/ports.md\`, which has just been rewritten to define three deployment modes (dotnet / docker +2000 / Conductor 9100+). Until this lands, Angular clients on canonical ports (4203 / 4204 / 4205 / 6200–6205) are silently blocked by CORS on the \`.well-known/openid-configuration\` fetch during OIDC discovery.

## Changes

- Every Andy Angular client origin across **dotnet + docker** modes, both \`http\` and \`https\`:
  - 4200–4205 (dotnet): andy-containers, -code-index, -docs, -issues, -agents, -tasks
  - 6200–6205 (docker, dotnet +2000)
- Conductor unified-proxy origin: \`http://localhost:9100\`
- Legacy 5180/5181/5320 entries preserved for andy-rbac and andy-narration internal UIs until those services migrate to Angular-style clients

## Verified

\`\`\`bash
docker compose build server && docker compose up -d server
curl -sk https://localhost:5001/.well-known/openid-configuration \\
     -H "Origin: https://localhost:4205" -D - -o /dev/null
# → access-control-allow-origin: https://localhost:4205
\`\`\`

End-to-end sign-in from andy-tasks at \`https://localhost:4205/\` now works.

## Follow-ups (separate PRs in this repo)

- \`DbSeeder.cs\`: drop legacy \`https://localhost:4200/callback\` from \`andy-tasks-web\` (that port belongs to andy-containers per the registry), \`andy-issues-web\`, \`andy-agents-web\`; add docker-mode (\`:6205/callback\`) and Conductor-mode (\`http://localhost:9100/tasks/callback\`) redirect URIs where missing
- \`appsettings.json\` (non-Development) — mirror the same expansion with production origins once those are assigned

Related: rivoli-ai/andy-tasks#8 (the OIDC consumer this unblocks), rivoli-ai/andy-service-template (the registry this syncs to).

🤖 Generated with [Claude Code](https://claude.com/claude-code)