### PR TITLE
DbSeeder: expand redirect URIs to cover three deployment modes

### DIFF
--- a/src/Andy.Auth.Server/Data/DbSeeder.cs
+++ b/src/Andy.Auth.Server/Data/DbSeeder.cs
@@ -719,14 +719,20 @@ public class DbSeeder
             RedirectUris =
             {
                 new Uri("https://localhost:4201/callback"),
-                new Uri("http://localhost:4201/callback")
+                new Uri("http://localhost:4201/callback"),
+                new Uri("https://localhost:6201/callback"),
+                new Uri("http://localhost:6201/callback"),
+                new Uri("http://localhost:9100/code-index/callback"),
             },
             PostLogoutRedirectUris =
             {
                 new Uri("https://localhost:4201/"),
                 new Uri("https://localhost:4201/login"),
                 new Uri("http://localhost:4201/"),
-                new Uri("http://localhost:4201/login")
+                new Uri("http://localhost:4201/login"),
+                new Uri("https://localhost:6201/"),
+                new Uri("http://localhost:6201/"),
+                new Uri("http://localhost:9100/code-index/"),
             }
         });
 
@@ -765,14 +771,20 @@ public class DbSeeder
             RedirectUris =
             {
                 new Uri("https://localhost:4200/callback"),
-                new Uri("http://localhost:4200/callback")
+                new Uri("http://localhost:4200/callback"),
+                new Uri("https://localhost:6200/callback"),
+                new Uri("http://localhost:6200/callback"),
+                new Uri("http://localhost:9100/containers/callback"),
             },
             PostLogoutRedirectUris =
             {
                 new Uri("https://localhost:4200/"),
                 new Uri("https://localhost:4200/login"),
                 new Uri("http://localhost:4200/"),
-                new Uri("http://localhost:4200/login")
+                new Uri("http://localhost:4200/login"),
+                new Uri("https://localhost:6200/"),
+                new Uri("http://localhost:6200/"),
+                new Uri("http://localhost:9100/containers/"),
             }
         });
 
@@ -1136,12 +1148,18 @@ public class DbSeeder
             RedirectUris =
             {
                 new Uri("https://localhost:4203/callback"),
-                new Uri("https://localhost:4200/callback"),
+                new Uri("http://localhost:4203/callback"),
+                new Uri("https://localhost:6203/callback"),
+                new Uri("http://localhost:6203/callback"),
+                new Uri("http://localhost:9100/issues/callback"),
             },
             PostLogoutRedirectUris =
             {
                 new Uri("https://localhost:4203/"),
-                new Uri("https://localhost:4200/"),
+                new Uri("http://localhost:4203/"),
+                new Uri("https://localhost:6203/"),
+                new Uri("http://localhost:6203/"),
+                new Uri("http://localhost:9100/issues/"),
             }
         });
 
@@ -1222,12 +1240,18 @@ public class DbSeeder
             RedirectUris =
             {
                 new Uri("https://localhost:4204/callback"),
-                new Uri("https://localhost:4200/callback"),
+                new Uri("http://localhost:4204/callback"),
+                new Uri("https://localhost:6204/callback"),
+                new Uri("http://localhost:6204/callback"),
+                new Uri("http://localhost:9100/agents/callback"),
             },
             PostLogoutRedirectUris =
             {
                 new Uri("https://localhost:4204/"),
-                new Uri("https://localhost:4200/"),
+                new Uri("http://localhost:4204/"),
+                new Uri("https://localhost:6204/"),
+                new Uri("http://localhost:6204/"),
+                new Uri("http://localhost:9100/agents/"),
             }
         });
 
@@ -1305,15 +1329,25 @@ public class DbSeeder
 
                 OpenIddictConstants.Permissions.ResponseTypes.Code
             },
+            // Redirect URIs span all three deployment modes per
+            // andy-service-template/docs/ports.md: dotnet native (4205),
+            // docker-compose (6205 = dotnet +2000), and Conductor embedded
+            // via the unified proxy (9100/tasks).
             RedirectUris =
             {
                 new Uri("https://localhost:4205/callback"),
-                new Uri("https://localhost:4200/callback"),
+                new Uri("http://localhost:4205/callback"),
+                new Uri("https://localhost:6205/callback"),
+                new Uri("http://localhost:6205/callback"),
+                new Uri("http://localhost:9100/tasks/callback"),
             },
             PostLogoutRedirectUris =
             {
                 new Uri("https://localhost:4205/"),
-                new Uri("https://localhost:4200/"),
+                new Uri("http://localhost:4205/"),
+                new Uri("https://localhost:6205/"),
+                new Uri("http://localhost:6205/"),
+                new Uri("http://localhost:9100/tasks/"),
             }
         });
 


### PR DESCRIPTION
Per rivoli-ai/andy-service-template#2 — every Angular client has three deployment modes (dotnet / docker +2000 / Conductor embedded). Seeder was only covering Mode 1 for most clients, and several still carried the legacy `https://localhost:4200/callback` redirect URI that originates from before the 42xx range was split per service.

## Changes per client

| Client | Before | After |
|---|---|---|
| andy-containers-web | 4200 only | + 6200 (docker), + /containers (Conductor) |
| andy-code-index-web | 4201 only | + 6201 (docker), + /code-index (Conductor) |
| andy-issues-web | 4203 + legacy 4200 | dropped 4200, + 6203, + /issues |
| andy-agents-web | 4204 + legacy 4200 | dropped 4200, + 6204, + /agents |
| andy-tasks-web | 4205 + legacy 4200 | dropped 4200, + 6205, + /tasks |

Other `*-web` clients (rbac, narration, wagram, agentic, subscription) are left alone — their ports don't match the 42xx registry today and warrant a separate conversation about which ones are canonical.

## Verified

Built + rebuilt the `andy-auth-server` container locally; sign-in flow from rivoli-ai/andy-tasks at `https://localhost:4205` continues to work (tested manually in this session).

Related:
- rivoli-ai/andy-service-template#2 — the registry this syncs to
- rivoli-ai/andy-auth#24 — the CORS sync that landed for the same reason
- rivoli-ai/andy-tasks#8 — consumer of Mode 1 :4205

🤖 Generated with [Claude Code](https://claude.com/claude-code)