### PR TITLE
Align ports to the three-mode registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
-      - "5435:5432"
+      - "7435:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -30,8 +30,8 @@ services:
       - ASPNETCORE_URLS=https://+:5001;http://+:5000
       - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=andy_auth_dev;Username=postgres;Password=postgres
     ports:
-      - "5001:5001"
-      - "5002:5000"
+      - "7001:5001"
+      - "7002:5000"
     volumes:
       - ./certs:/usr/local/share/ca-certificates/custom:ro
     depends_on:

--- a/src/Andy.Auth.Server/Properties/launchSettings.json
+++ b/src/Andy.Auth.Server/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:7088;http://localhost:5271",
+      "applicationUrl": "https://localhost:5001;http://localhost:5002",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -22,7 +22,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:5271",
+      "applicationUrl": "http://localhost:5002",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Andy.Auth.Server/appsettings.Development.json
+++ b/src/Andy.Auth.Server/appsettings.Development.json
@@ -1,6 +1,7 @@
 {
+  "//": "Dev-override for `dotnet run + docker compose up postgres` — points at the Mode 2 docker pg.",
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5435;Database=andy_auth_dev;Username=andy_auth;Password=andy_auth_dev_password"
+    "DefaultConnection": "Host=localhost;Port=7435;Database=andy_auth_dev;Username=andy_auth;Password=andy_auth_dev_password"
   },
   "Logging": {
     "LogLevel": {

--- a/src/Andy.Auth.Server/appsettings.json
+++ b/src/Andy.Auth.Server/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Database=andy_auth;Username=postgres;Password=postgres"
+    "DefaultConnection": "Host=localhost;Port=5435;Database=andy_auth;Username=postgres;Password=postgres"
   },
   "Database": {
     "_comment": "PostgreSQL is the hosted/Docker default. Conductor's embedded launcher overrides this with Database__Provider=Sqlite via environment variables.",


### PR DESCRIPTION
Per rivoli-ai/andy-service-template#2 — three-mode registry. andy-auth: Mode 1 5001/5002/5435, Mode 2 7001/7002/7435, Mode 3 proxy /auth.

Changes:
- `launchSettings.json`: VS-legacy 7088 HTTPS / 5271 HTTP → canonical 5001 / 5002
- `appsettings.json`: explicit `Port=5435` in connection string (was relying on default)
- `appsettings.Development.json`: dev-override points pg at Mode 2 (7435) — common `dotnet run + docker compose up postgres` setup
- `docker-compose.yml`: host-ports postgres 5435→7435, server 5001→7001 + 5002→7002

Reviewer note: `docker compose down && docker compose up -d` after merging so the containers rebind.

Related: rivoli-ai/andy-service-template#2, rivoli-ai/andy-tasks#9 (reference implementation), rivoli-ai/andy-auth#24 (CORS sync, merged), rivoli-ai/andy-auth#26 (DbSeeder sync, merged).