### PR TITLE
Set deterministic Id for test@andy.local seed user

### DIFF
--- a/src/Andy.Auth.Server/Data/DbSeeder.cs
+++ b/src/Andy.Auth.Server/Data/DbSeeder.cs
@@ -8,6 +8,15 @@ namespace Andy.Auth.Server.Data;
 /// </summary>
 public class DbSeeder
 {
+    /// <summary>
+    /// Deterministic <c>ApplicationUser.Id</c> (and JWT <c>sub</c> claim) for
+    /// <c>test@andy.local</c> in non-Production environments. Exposed so
+    /// downstream ecosystem services (andy-rbac, consumer integration tests)
+    /// can pre-bind roles and permissions to this subject without runtime
+    /// coordination. See rivoli-ai/andy-auth#56.
+    /// </summary>
+    public const string TestUserWellKnownId = "00000000-0000-0000-0000-000000000001";
+
     private readonly IServiceProvider _serviceProvider;
     private readonly IConfiguration _configuration;
     private readonly ILogger<DbSeeder> _logger;
@@ -1093,6 +1102,7 @@ public class DbSeeder
             {
                 var testUser = new ApplicationUser
                 {
+                    Id = TestUserWellKnownId,
                     UserName = testEmail,
                     Email = testEmail,
                     EmailConfirmed = true,
@@ -1106,7 +1116,7 @@ public class DbSeeder
                 {
                     // Assign User role to test user (not Admin)
                     await userManager.AddToRoleAsync(testUser, "User");
-                    _logger.LogInformation("Created test user: {Email} with password 'Test123!' in {Environment} environment", testEmail, environment);
+                    _logger.LogInformation("Created test user: {Email} with deterministic Id {UserId} in {Environment} environment", testEmail, testUser.Id, environment);
                 }
                 else
                 {
@@ -1115,6 +1125,19 @@ public class DbSeeder
             }
             else
             {
+                // Id is the primary key + FK anchor for Identity-related rows; mutating
+                // it in place would orphan history. If an older non-deterministic Id
+                // exists from a pre-#56 upgrade, log and leave alone — operators can
+                // delete + recreate manually if they need the deterministic Id.
+                if (existingTestUser.Id != TestUserWellKnownId)
+                {
+                    _logger.LogWarning(
+                        "Test user {Email} exists with Id {ActualId} rather than the well-known {ExpectedId}. " +
+                        "Downstream services that pre-bind roles by Id (andy-rbac et al) will not match this user. " +
+                        "To reset: delete the user via the admin UI and restart andy-auth.",
+                        testEmail, existingTestUser.Id, TestUserWellKnownId);
+                }
+
                 // Reset password for existing test user to ensure it's always Test123!
                 var token = await userManager.GeneratePasswordResetTokenAsync(existingTestUser);
                 var resetResult = await userManager.ResetPasswordAsync(existingTestUser, token, "Test123!");

--- a/tests/Andy.Auth.Server.Tests/DbSeederTests.cs
+++ b/tests/Andy.Auth.Server.Tests/DbSeederTests.cs
@@ -208,6 +208,7 @@ public class DbSeederTests
         // Assert
         _mockUserManager.Verify(m => m.CreateAsync(
             It.Is<ApplicationUser>(u =>
+                u.Id == DbSeeder.TestUserWellKnownId && // #56 — deterministic Id for downstream pre-binding
                 u.Email == "test@andy.local" &&
                 u.UserName == "test@andy.local" &&
                 u.EmailConfirmed == true &&
@@ -215,6 +216,15 @@ public class DbSeederTests
                 u.IsActive == true),
             "Test123!"),
             Times.Once);
+    }
+
+    [Fact]
+    public void TestUserWellKnownId_IsTheDocumentedConstant()
+    {
+        // Locks the Id contract so changing it requires a deliberate update —
+        // downstream consumers (andy-rbac, andy-policies E2E) hardcode the same
+        // string and would silently miss bindings if it drifted.
+        Assert.Equal("00000000-0000-0000-0000-000000000001", DbSeeder.TestUserWellKnownId);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #56.

## Summary

The test user (\`test@andy.local\`, seeded in non-Production environments) previously got a random Guid Id from ASP.NET Identity. That random Id became the JWT \`sub\` claim, blocking sibling services (andy-rbac et al) from pre-binding roles to this user during their own startup seeders — they couldn't know what subject identifier to use without runtime coordination.

This pins the Id to a documented constant exposed as \`DbSeeder.TestUserWellKnownId\`:

\`\`\`csharp
public const string TestUserWellKnownId = \"00000000-0000-0000-0000-000000000001\";
\`\`\`

The same well-known constant is hardcoded in andy-rbac's \`DataSeeder\` (rivoli-ai/andy-rbac#52). Together they unblock E2E permission tests in consumer services (rivoli-ai/andy-policies#109).

## Behaviour

- **New test user creations** get the well-known Id.
- **Existing test users from pre-#56 deployments** are left alone — \`Id\` is Identity's primary key + FK anchor, so mutating in place would orphan history. The seeder logs a warning if the Id doesn't match, pointing operators at the manual reset path (delete via admin UI + restart).
- Production guard unchanged.

## Test plan

- [x] New test \`TestUserWellKnownId_IsTheDocumentedConstant\` — locks the string value so it can't drift without updating downstream services. Passes.
- [x] Existing \`SeedAsync_ShouldCreateTestUser_InDevelopmentEnvironment\` updated to assert the deterministic Id on the created user.
- [ ] **Pre-existing test infra failure (unrelated to this PR):** most \`DbSeederTests\` fail at startup with \`No service for type ILogger<RegistrationManifestLoader>\` — a missing DI registration in the test harness introduced when manifest loading landed in #43. Verified by running the same modified test on main and confirming identical failure. Worth a separate cleanup PR.

## Cross-repo

- **rivoli-ai/andy-rbac#52** — DataSeeder will use this constant when binding manifest-declared \`testUserRole\`. PR opens immediately after this one.
- **rivoli-ai/andy-policies#109** — E2E permission test, unblocked by both this and #52 landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)