### PR TITLE
chore: strip dead wagram-* URLs + fix JSON syntax error in appsettings.UAT.json (E0-S7, andy-auth slice)

### DIFF
--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -118,12 +118,15 @@ The admin dashboard provides a web-based interface for managing Andy Auth Server
   - Refresh token grant
   - Authorization code grant
 
-**wagram-web** (Public)
-- Client ID: `wagram-web`
+**andy-docs-web** (Public)
+- Client ID: `andy-docs-web` *(renamed from `wagram-web` per E0-S6, rivoli-ai/andy-auth#25)*
 - No client secret (public SPA)
 - Redirect URIs:
-  - https://wagram.ai/callback
-  - http://localhost:4200/callback
+  - `http://localhost:4202/auth/callback` (canonical dotnet local port per andy-service-template/docs/ports.md)
+  - `http://localhost:6202/auth/callback` (docker-compose mode)
+  - `http://localhost:9100/docs/auth/callback` (Conductor embedded)
+  - `https://docs.uat.wagram.ai/auth/callback` (UAT)
+  - `https://docs.wagram.ai/auth/callback` (Production)
 - Permissions:
   - Authorization endpoint
   - Token endpoint

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -237,8 +237,8 @@ VITE_API_URL=https://andy-docs-api.rivoli.ai
 ```typescript
 export const environment = {
   authUrl: 'https://auth.rivoli.ai',
-  clientId: 'wagram-web',
-  redirectUri: 'https://wagram.ai/callback'
+  clientId: 'andy-docs-web',
+  redirectUri: 'https://docs.wagram.ai/auth/callback'
 };
 ```
 

--- a/docs/presentation.md
+++ b/docs/presentation.md
@@ -109,7 +109,7 @@ andy-auth/
 | Client | Type | Purpose |
 |--------|------|---------|
 | `andy-docs-api` | Confidential | S2S for MCP backend |
-| `wagram-web` | Public SPA | Angular/React web app |
+| `andy-docs-web` | Public SPA | Angular web app *(renamed from wagram-web per E0-S6)* |
 | `claude-desktop` | Public | Claude Desktop MCP |
 | `chatgpt` | Public | ChatGPT MCP |
 | `cline`, `roo`, `continue-dev` | Public | VS Code extensions |
@@ -241,12 +241,12 @@ Then `[Authorize]` on controllers. Middleware fetches JWKS, validates RS256, che
 ## Data Flow — Auth Code + PKCE Login (1/2)
 
 1. **SPA** generates `code_verifier` + `code_challenge = Base64URL(SHA256(verifier))`
-2. **SPA** → `GET /connect/authorize?client_id=wagram-web&response_type=code&code_challenge=…&code_challenge_method=S256&scope=openid profile email offline_access urn:andy-docs-api`
+2. **SPA** → `GET /connect/authorize?client_id=andy-docs-web&response_type=code&code_challenge=…&code_challenge_method=S256&scope=openid profile email offline_access urn:andy-docs-api`
 3. **AuthorizationController**: not authenticated → `Challenge()` → redirect to `/Account/Login`
 4. **User** submits email+password → cookie set → back to `/connect/authorize`
 5. **Consent screen** (first time) — user clicks **Allow**
 6. **Server** mints authorization `code` (~10 min TTL, stores `code_challenge`)
-7. **Redirect** → `https://wagram.ai/callback?code=…&state=…`
+7. **Redirect** → `https://docs.wagram.ai/auth/callback?code=…&state=…`
 
 ---
 

--- a/src/Andy.Auth.Server/appsettings.Production.json
+++ b/src/Andy.Auth.Server/appsettings.Production.json
@@ -12,9 +12,7 @@
   "CorsOrigins": {
     "AllowedOrigins": [
       "https://wagram.ai",
-      "https://www.wagram.ai",
-      "https://wagram-uat.vercel.app",
-      "https://wargram-ai-uat.vercel.app"
+      "https://www.wagram.ai"
     ]
   },
   "OpenIddict": {

--- a/src/Andy.Auth.Server/appsettings.UAT.json
+++ b/src/Andy.Auth.Server/appsettings.UAT.json
@@ -12,9 +12,7 @@
   "CorsOrigins": {
     "AllowedOrigins": [
       "https://wagram.ai",
-      "https://www.wagram.ai",
-      "https://wagram-uat.vercel.app",
-https://wargram-ai-uat.vercel.app
+      "https://www.wagram.ai"
     ]
   },
   "OpenIddict": {

--- a/tests/oauth-python/config.py
+++ b/tests/oauth-python/config.py
@@ -67,8 +67,8 @@ CLIENTS: Dict[str, ClientConfig] = {
         is_confidential=False,
         redirect_uris=[
             "https://localhost:4200/callback",
-            "https://wagram-uat.vercel.app/callback",
-            "https://wagram.ai/callback"
+            "https://docs.uat.wagram.ai/auth/callback",
+            "https://docs.wagram.ai/auth/callback"
         ],
         scopes=["openid", "profile", "email", "roles", "urn:andy-docs-api"],
         supports_client_credentials=False,

--- a/tests/oauth-python/oauth-flow-test.py
+++ b/tests/oauth-python/oauth-flow-test.py
@@ -339,7 +339,7 @@ def main():
         redirect_uri = 'https://localhost:4200/callback'
     else:  # uat
         base_url = 'https://andy-auth-uat-api.up.railway.app'
-        redirect_uri = 'https://wagram-uat.vercel.app/callback'
+        redirect_uri = 'https://docs.uat.wagram.ai/auth/callback'
 
     client_id = 'wagram-web'
 


### PR DESCRIPTION
## Summary
Strips dead Wagram-era Vercel URLs from CORS allowlists, OAuth integration tests, and docs. **Bonus fix**: \`appsettings.UAT.json\` had a JSON syntax error — \`wargram-ai-uat.vercel.app\` was unquoted on line 17 — which meant the file was malformed and would fail to load in UAT environment. Dropping the dead URLs cleans both issues at once.

Per the 2026-04-25 maintainer decision (rivoli-ai/andy-docs#288), the bare \`wagram.ai\` apex stays as the canonical brand domain; only legacy *subdomain* prefixes (\`wagram-uat.vercel.app\`, \`wargram-ai-uat.vercel.app\`) and dead callback URLs are stripped.

## Files
- \`src/Andy.Auth.Server/appsettings.UAT.json\` — drops 2 dead Vercel URLs + fixes the unquoted-value JSON syntax error.
- \`src/Andy.Auth.Server/appsettings.Production.json\` — drops the same 2 dead URLs (syntactically valid before; cleaner now).
- \`docs/ADMIN.md\` — \`wagram-web\` client section renamed to \`andy-docs-web\` with the full canonical 5-URI redirect set (mirrors what rivoli-ai/andy-auth#60 puts into the seeder).
- \`docs/presentation.md\` — \`wagram-web\` → \`andy-docs-web\` in the client table + OAuth flow example, \`https://wagram.ai/callback\` → \`https://docs.wagram.ai/auth/callback\`.
- \`docs/DEPLOYMENT.md\` — \`clientId\` + \`redirectUri\` in the SPA env example flipped to canonical Andy values.
- \`tests/oauth-python/oauth-flow-test.py\` + \`tests/oauth-python/config.py\` — dead Vercel callback URLs flipped to canonical \`docs.wagram.ai\` / \`docs.uat.wagram.ai\`.

## Coordination
- **Stacks cleanly with rivoli-ai/andy-auth#60** (E0-S6 — \`wagram-web\` → \`andy-docs-web\` rename in DbSeeder + AuthorizationController). rivoli-ai/conductor#60 touches different files in the same repo (\`Data/DbSeeder.cs\`, \`Controllers/AuthorizationController.cs\`); no merge conflict expected.
- The bare \`wagram.ai\` / \`www.wagram.ai\` entries in \`appsettings.*.json\` CORS allowlists are *kept*. Full CORS-list rewrite to the canonical Andy subdomain set (per E3-S4's design) is rivoli-ai/andy-auth#59 territory.

## JSON syntax error worth noting
\`appsettings.UAT.json\` line 17 was \`https://wargram-ai-uat.vercel.app\` (no quotes, no comma). Any host loading this file in \`UAT\` environment would have hit a JSON parse error at startup. Worth tracing whether anything ever booted in UAT against this file — the parse failure may have been silently swallowed by host-builder fallback. Out of scope for this PR; flagging for future investigation.

## Closes
- Part of rivoli-ai/andy-docs#289 (E0-S7 — andy-auth slice).

## Test plan
- [ ] \`dotnet build\` succeeds (verified locally: 0 errors, 9 pre-existing warnings).
- [ ] \`python3 -c "import json; json.load(open(...))"\` parses all three appsettings files cleanly (verified locally).
- [ ] \`tests/oauth-python\` integration tests reach the expected endpoints (run as part of integration test pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)