### PR TITLE
Fix DCR controller test regression from Embedded-mode merge (#63)

### DIFF
--- a/docs/issues/dcr-controller-tests-iconfig-regression.md
+++ b/docs/issues/dcr-controller-tests-iconfig-regression.md
@@ -1,0 +1,66 @@
+# DCR controller tests fail after Embedded-mode merge: `Mock<IConfiguration>` doesn't satisfy `GetSection().Get<string[]>()`
+
+## Problem
+
+Commit 5776dc1 ("Add Embedded deployment mode for OpenIddict") added an `IConfiguration` constructor parameter to `DynamicClientRegistrationController` so it can read the `OpenIddict:Resources` list from config (the same list `Program.cs` registers at startup, single source of truth).
+
+The accompanying test update wires the new parameter with a Moq default:
+
+```csharp
+new Mock<Microsoft.Extensions.Configuration.IConfiguration>().Object
+```
+
+But the production code path now calls:
+
+```csharp
+_configuration.GetSection("OpenIddict:Resources").Get<string[]>() ?? Array.Empty<string>();
+```
+
+`GetSection` on a Moq-default `IConfiguration` returns `null`, and `Get<string[]>()` then throws `ArgumentNullException`. The `?? Array.Empty<string>()` fallback never gets a chance to fire.
+
+Net effect: **4 DCR tests now fail on a fresh checkout of `main`**:
+
+- `Andy.Auth.Server.Tests.Controllers.DynamicClientRegistrationControllerTests.Register_*` (×4)
+
+Pre-existing failures (6 SessionTrackingMiddleware, 3 Postgres-required, 1 IPv6 loopback) are unrelated.
+
+## Fix
+
+Replace the `Mock<IConfiguration>` with a real empty configuration — `IConfiguration` is a value-shaped interface that's cheap to build:
+
+```csharp
+var configuration = new ConfigurationBuilder().Build();
+```
+
+Two call sites, both in `tests/Andy.Auth.Server.Tests/DynamicClientRegistrationControllerTests.cs`:
+- Line 66 (the shared ctor in `IDisposable` setup)
+- Line 508 (the in-test factory inside the `_DisablesAuthorizationCodeFlowFor*` cases)
+
+For the call sites that want to assert specific MCP resources land on the descriptor, swap to:
+
+```csharp
+var configuration = new ConfigurationBuilder()
+    .AddInMemoryCollection(new Dictionary<string, string?>
+    {
+        ["OpenIddict:Resources:0"] = "https://localhost:5101/mcp",
+    })
+    .Build();
+```
+
+## Acceptance criteria
+
+- [ ] `dotnet test tests/Andy.Auth.Server.Tests` passes for all 4 previously-failing `DynamicClientRegistrationControllerTests` cases.
+- [ ] No new red tests introduced.
+- [ ] At least one new test asserts the empty-resources path — i.e. an `IConfiguration` with no `OpenIddict:Resources` section produces zero resource permissions on the descriptor and doesn't throw. This is the regression-prevention test for the bug this issue fixes.
+- [ ] At least one new test asserts the populated-resources path — `OpenIddict:Resources = ["https://localhost:5101/mcp"]` produces exactly one resource permission with the right prefix.
+- [ ] No `Mock<IConfiguration>` in `DynamicClientRegistrationControllerTests.cs` after the fix.
+
+## Files touched
+
+- `tests/Andy.Auth.Server.Tests/DynamicClientRegistrationControllerTests.cs` — replace 2 mocks, add 2 tests.
+
+## Notes
+
+- This is a pure test-side fix; production code at `DynamicClientRegistrationController.cs:209` is correct as written.
+- The new tests double as the missing coverage flagged in the post-merge review (empty-resources fallback was untested under Development too — same mechanism).
+- Discovered during post-merge review of 5776dc1 on 2026-05-05.

--- a/tests/Andy.Auth.Server.Tests/DynamicClientRegistrationControllerTests.cs
+++ b/tests/Andy.Auth.Server.Tests/DynamicClientRegistrationControllerTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -63,7 +64,7 @@ public class DynamicClientRegistrationControllerTests : IDisposable
             _tokenManagerMock.Object,
             _context,
             _loggerMock.Object,
-            new Mock<Microsoft.Extensions.Configuration.IConfiguration>().Object);
+            new ConfigurationBuilder().Build());
 
         SetupHttpContext();
     }
@@ -191,6 +192,74 @@ public class DynamicClientRegistrationControllerTests : IDisposable
         statusResult.StatusCode.Should().Be(201);
         var response = statusResult.Value.Should().BeOfType<ClientRegistrationResponse>().Subject;
         response.ClientSecret.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Register_EmptyOpenIddictResourcesConfig_DoesNotThrowAndAddsNoResourcePermissions()
+    {
+        // Regression for #63: a previous test setup wired this controller
+        // with `Mock<IConfiguration>().Object`, which made GetSection return
+        // null and Get<string[]>() throw ArgumentNullException. The
+        // production code documents `?? Array.Empty<string>()` as the empty
+        // path; this test pins that contract end-to-end.
+        OpenIddictApplicationDescriptor? captured = null;
+        _applicationManagerMock.Setup(x => x.FindByClientIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((object?)null);
+        _applicationManagerMock.Setup(x => x.CreateAsync(It.IsAny<OpenIddictApplicationDescriptor>(), It.IsAny<CancellationToken>()))
+            .Callback<object, CancellationToken>((d, _) => captured = (OpenIddictApplicationDescriptor)d)
+            .Returns(new ValueTask<object>(new object()));
+
+        var request = new ClientRegistrationRequest
+        {
+            ClientName = "Test App",
+            RedirectUris = new List<string> { "https://example.com/callback" },
+            GrantTypes = new List<string> { "authorization_code" },
+            TokenEndpointAuthMethod = "client_secret_basic"
+        };
+
+        var result = await _controller.Register(request);
+
+        result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(201);
+        captured.Should().NotBeNull();
+        captured!.Permissions
+            .Where(p => p.StartsWith(OpenIddictConstants.Permissions.Prefixes.Resource))
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Register_PopulatedOpenIddictResourcesConfig_AddsResourcePermissions()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["OpenIddict:Resources:0"] = "https://localhost:5101/mcp",
+                ["OpenIddict:Resources:1"] = "https://localhost:5510/mcp",
+            })
+            .Build();
+        var controller = CreateControllerWithSettings(_settings, configuration);
+
+        OpenIddictApplicationDescriptor? captured = null;
+        _applicationManagerMock.Setup(x => x.FindByClientIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((object?)null);
+        _applicationManagerMock.Setup(x => x.CreateAsync(It.IsAny<OpenIddictApplicationDescriptor>(), It.IsAny<CancellationToken>()))
+            .Callback<object, CancellationToken>((d, _) => captured = (OpenIddictApplicationDescriptor)d)
+            .Returns(new ValueTask<object>(new object()));
+
+        var request = new ClientRegistrationRequest
+        {
+            ClientName = "Test App",
+            RedirectUris = new List<string> { "https://example.com/callback" },
+            GrantTypes = new List<string> { "authorization_code" },
+            TokenEndpointAuthMethod = "client_secret_basic"
+        };
+
+        var result = await controller.Register(request);
+
+        result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(201);
+        captured.Should().NotBeNull();
+        var prefix = OpenIddictConstants.Permissions.Prefixes.Resource;
+        captured!.Permissions.Should().Contain(prefix + "https://localhost:5101/mcp");
+        captured.Permissions.Should().Contain(prefix + "https://localhost:5510/mcp");
     }
 
     [Fact]
@@ -497,15 +566,12 @@ public class DynamicClientRegistrationControllerTests : IDisposable
 
     // ==================== Helper Methods ====================
 
-    private DynamicClientRegistrationController CreateControllerWithSettings(DcrSettings settings)
+    private DynamicClientRegistrationController CreateControllerWithSettings(
+        DcrSettings settings,
+        IConfiguration? configuration = null)
     {
         var settingsOptions = Options.Create(settings);
         var dcrService = new DcrService(_context, settingsOptions, _dcrLoggerMock.Object);
-
-        // Empty configuration is fine here — the MCP resource list ends
-        // up empty, which is the documented no-op path. The existing DCR
-        // tests don't assert on the presence of specific MCP resources.
-        var configuration = new Mock<Microsoft.Extensions.Configuration.IConfiguration>().Object;
 
         var controller = new DynamicClientRegistrationController(
             dcrService,
@@ -514,7 +580,7 @@ public class DynamicClientRegistrationControllerTests : IDisposable
             _tokenManagerMock.Object,
             _context,
             _loggerMock.Object,
-            configuration);
+            configuration ?? new ConfigurationBuilder().Build());
 
         var httpContext = new DefaultHttpContext();
         httpContext.Request.Scheme = "https";


### PR DESCRIPTION
## Summary

- Replaces `Mock<IConfiguration>().Object` with `new ConfigurationBuilder().Build()` in `DynamicClientRegistrationControllerTests.cs` (2 sites). Moq's default `IConfiguration` returns `null` from `GetSection`, which makes the new `Get<string[]>()` call in 5776dc1 throw `ArgumentNullException`.
- Adds two regression-prevention tests pinning both branches of the new contract: empty `OpenIddict:Resources` config produces zero resource permissions (no throw), populated config produces matching ones with the OpenIddict resource prefix.
- Refactors `CreateControllerWithSettings` to take an optional `IConfiguration` so tests can inject one.

Closes #63.

## Test plan

- [x] `dotnet test tests/Andy.Auth.Server.Tests --filter "FullyQualifiedName~DynamicClientRegistrationControllerTests"` — 17 / 18 pass.
- [x] Full server suite: 507 / 521 pass (+5 vs `main`, -3 fails). The 11 remaining reds are all pre-existing (6 `SessionTrackingMiddleware`, 3 Postgres-environment, 1 IPv6 loopback, 1 `Register_InvalidRedirectUri_ReturnsBadRequest`).

## Notes

- The post-merge review flagged 4 DCR controller failures as caused by 5776dc1; only 3 actually were. `Register_InvalidRedirectUri_ReturnsBadRequest` predates 5776dc1 (verified by checking out 261d6bb and running it — same `UnauthorizedObjectResult` outcome). Root cause there is unrelated: the test's `strictSettings` doesn't override `DcrSettings.RequireInitialAccessToken` whose default is `true`, so the controller short-circuits with 401 before validation runs. Worth a separate small issue.