### PR TITLE
Production: load OpenIddict signing keys from disk so JWKS survives redeploy (closes #69)

### DIFF
--- a/docs/issues/production-signing-keys-path.md
+++ b/docs/issues/production-signing-keys-path.md
@@ -1,0 +1,36 @@
+# Production: load OpenIddict signing keys from disk so JWKS survives redeploy
+
+## Problem
+
+`Program.cs:227-232` is currently a placeholder for the Production branch. If `OpenIddict:UseEphemeralKeys != true` it throws `InvalidOperationException("Production environment requires explicit configuration...")`. There is no real persisted-key path — every UAT/Prod deploy is forced into ephemeral keys, which means every container restart rotates JWKS and invalidates every cached JWT held by every consumer.
+
+The deploy story #59 (E3-S4 — Deploy andy-auth to Railway) calls for `OpenIddict__SigningKeys__Path = /data/keys` on a Railway volume, and explicitly notes "rotating keys breaks every issued token." That's the same mechanism Embedded mode already uses (`PersistedDevelopmentKeys.AddPersistedDevelopmentKeys`) — the helper is general-purpose RSA-on-disk, the `Development` in its name is historic.
+
+## Fix
+
+In the Production branch of `Program.cs`, prefer a persisted-keys path:
+
+1. If `OpenIddict:SigningKeys:Path` is set → call `AddPersistedDevelopmentKeys(path)` (same helper Embedded uses). JWKS `kid` stable across restarts.
+2. Else if `OpenIddict:UseEphemeralKeys=true` → ephemeral keys (current Railway-pod fallback for stateless deploys).
+3. Else → hard-fail boot with a message that documents both options.
+
+## Acceptance criteria
+
+- [ ] Production branch in `Program.cs` accepts `OpenIddict:SigningKeys:Path` and uses it to persist RSA signing+encryption keys via the existing `AddPersistedDevelopmentKeys` helper.
+- [ ] When the path is set, JWKS `kid` survives a process restart (integration test against `WebApplicationFactory<Program>` with Production env).
+- [ ] When neither `SigningKeys:Path` nor `UseEphemeralKeys=true` is set, boot fails with a message that lists both paths.
+- [ ] `appsettings.Production.json` does NOT add a placeholder for the path. Reasoning: the existing `Issuer = SET_VIA_ENVIRONMENT_VARIABLE` placeholder fails loudly at boot via `new Uri(...)`, but a string placeholder for a directory path would silently `Directory.CreateDirectory("SET_VIA_ENVIRONMENT_VARIABLE")` — fail-quiet, the wrong behaviour. The Program.cs throw with both options listed is the documentation.
+- [ ] `OpenIddict:UseEphemeralKeys=true` continues to work as the explicit opt-out for stateless Railway pods.
+
+## Files touched
+
+- `src/Andy.Auth.Server/Program.cs` — extend the Production branch (lines 227-232).
+- `src/Andy.Auth.Server/Configuration/PersistedDevelopmentKeys.cs` — minor doc-comment touch-up acknowledging Production reuse (no rename — out of scope).
+- `src/Andy.Auth.Server/appsettings.Production.json` — add the placeholder.
+- `tests/Andy.Auth.Server.Tests/ProductionModeIntegrationTests.cs` — new file mirroring `EmbeddedModeIntegrationTests` for the Production env.
+
+## Notes
+
+- Could rename `PersistedDevelopmentKeys` → `PersistedSigningKeys` for accuracy. Deferred — the rename has surface area (file, class, method, tests) that doesn't fit this PR's scope.
+- True X.509 PFX-from-vault support is a separate future story. The deploy story (#59) chose Railway-volume RSA, which is what this PR enables.
+- Symlink/permission hardening on the keys path is also covered by the existing #46-adjacent review note; out of scope here.

--- a/src/Andy.Auth.Server/Configuration/PersistedDevelopmentKeys.cs
+++ b/src/Andy.Auth.Server/Configuration/PersistedDevelopmentKeys.cs
@@ -6,26 +6,33 @@ namespace Andy.Auth.Server.Configuration;
 
 // File-backed signing + encryption keys for deployment modes where the
 // server restarts frequently but clients hold long-lived tokens across
-// restarts (specifically: Conductor embedded mode).
+// restarts. Used by Conductor embedded mode (single-user desktop app
+// with keys at `~/.conductor/keys`) and by Production deploys with a
+// mounted volume (e.g. Railway `/data/keys` per E3-S4) — same RSA
+// PEM-on-disk mechanism, different host trust model.
 //
 // AddEphemeralSigningKey()/AddEphemeralEncryptionKey() generate keys
 // in memory and rotate them on every process start. That is fine for
 // `dotnet run` development (browser clients reauthenticate on reload)
 // but catastrophic when the same server is bundled inside a desktop
-// app that the user relaunches frequently — every relaunch invalidates
-// every previously-minted JWT and every downstream service starts
-// returning 401 until a token refresh races through.
+// app that the user relaunches frequently, or when it sits behind a
+// production load balancer where consumers hold issued JWTs across
+// pod restarts — every restart invalidates every previously-minted
+// JWT and every downstream service starts returning 401 until a token
+// refresh races through.
 //
 // This helper persists a 2048-bit RSA keypair as unencrypted PKCS#8
 // PEM to `<directoryPath>/signing.key` and `<directoryPath>/encryption.key`.
 // On first boot the keys are generated and written; on subsequent
 // boots they are loaded verbatim so the JWKS `kid` stays constant.
 //
-// Security model: the keys protect a local, single-user session
-// inside a desktop app. Directory+file permissions (0700/0600 on
-// Unix) gate access to the owning user. This is intentionally not
-// a replacement for the production X.509 certificate path, which
-// remains the correct choice for hosted multi-tenant deployments.
+// Security model: directory+file permissions (0700/0600 on Unix) gate
+// access to the process's owning user. For Embedded that's the desktop
+// user; for Production that's the container's service account. The
+// volume itself must be the trust boundary — anyone who can read
+// `signing.key` can mint tokens. PFX-from-key-vault is a future
+// alternative for environments that need a tighter trust boundary,
+// but is not implemented here (see #69).
 public static class PersistedDevelopmentKeys
 {
     /// <summary>

--- a/src/Andy.Auth.Server/Program.cs
+++ b/src/Andy.Auth.Server/Program.cs
@@ -218,24 +218,36 @@ builder.Services.AddOpenIddict()
         }
         else if (builder.Environment.IsProduction())
         {
-            // Check if running in Railway/Cloud with ephemeral keys flag
+            // Production prefers persisted RSA keys on a mounted volume
+            // (e.g. Railway `/data/keys` per E3-S4) so JWKS `kid` survives
+            // redeploys and every previously-issued JWT keeps validating.
+            // Falls back to ephemeral keys for stateless cloud pods that
+            // explicitly opt in via `OpenIddict:UseEphemeralKeys=true`.
+            var keysPath = builder.Configuration["OpenIddict:SigningKeys:Path"];
             var useEphemeralKeys = builder.Configuration.GetValue<bool>("OpenIddict:UseEphemeralKeys", false);
 
-            if (useEphemeralKeys)
+            if (!string.IsNullOrWhiteSpace(keysPath))
             {
-                // Use ephemeral keys for cloud deployments (Railway, etc.)
-                // WARNING: These keys will change on restart, invalidating all tokens
+                options.AddPersistedDevelopmentKeys(keysPath)
+                       .DisableAccessTokenEncryption();
+            }
+            else if (useEphemeralKeys)
+            {
+                // Stateless deploy — keys rotate on every restart, every
+                // token in flight becomes invalid. Acceptable only when
+                // every consumer can re-auth on demand.
                 options.AddEphemeralEncryptionKey()
                        .AddEphemeralSigningKey()
                        .DisableAccessTokenEncryption();
             }
             else
             {
-                // Production: Load certificates from configuration or key vault
                 throw new InvalidOperationException(
-                    "Production environment detected. Please configure proper signing and encryption certificates " +
-                    "or set OpenIddict:UseEphemeralKeys=true for UAT deployments. " +
-                    "See docs/DEPLOYMENT.md for instructions.");
+                    "Production requires either `OpenIddict:SigningKeys:Path` (recommended — " +
+                    "RSA keypair persisted on a mounted volume so JWKS survives redeploy) " +
+                    "or `OpenIddict:UseEphemeralKeys=true` (rotates keys every restart and " +
+                    "invalidates every issued token; only safe for stateless pods where " +
+                    "every consumer can re-auth on demand).");
             }
         }
 

--- a/tests/Andy.Auth.Server.Tests/ProductionModeIntegrationTests.cs
+++ b/tests/Andy.Auth.Server.Tests/ProductionModeIntegrationTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Andy.Auth.Server.Tests;
+
+// Integration tests for ASPNETCORE_ENVIRONMENT=Production. The
+// invariants here mirror the Embedded suite — the persisted-keys
+// mechanism is shared — but cover the Production-only branching:
+//   1. With `OpenIddict:SigningKeys:Path` set, RSA keys persist on
+//      disk and JWKS `kid` survives a process restart. This is the
+//      Railway-volume deploy shape (#69 / E3-S4).
+//   2. With `OpenIddict:UseEphemeralKeys=true`, boot succeeds and
+//      JWKS is served — stateless cloud-pod fallback.
+//   3. With neither, boot hard-fails with a message that documents
+//      both options. The previous placeholder behaviour was the
+//      same throw but with a less specific message.
+public class ProductionModeIntegrationTests : IDisposable
+{
+    private readonly string _keysDir;
+    private readonly string _dbPath;
+
+    public ProductionModeIntegrationTests()
+    {
+        var baseTemp = Path.Combine(
+            Path.GetTempPath(),
+            "andy-auth-prod-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(baseTemp);
+        _keysDir = Path.Combine(baseTemp, "keys");
+        _dbPath = Path.Combine(baseTemp, "andy-auth.sqlite");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            var parent = Path.GetDirectoryName(_keysDir);
+            if (parent != null && Directory.Exists(parent))
+            {
+                Directory.Delete(parent, recursive: true);
+            }
+        }
+        catch (IOException) { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task ProductionBoot_WithKeysPath_PersistsKeysToDisk()
+    {
+        using var factory = new ProductionWebApplicationFactory(
+            keysPath: _keysDir,
+            useEphemeralKeys: false,
+            dbPath: _dbPath);
+        using var client = HttpsClient(factory);
+
+        var response = await client.GetAsync("/.well-known/openid-configuration");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        File.Exists(Path.Combine(_keysDir, "signing.key")).Should().BeTrue();
+        File.Exists(Path.Combine(_keysDir, "encryption.key")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ProductionBoot_WithKeysPath_JwksIsStableAcrossRestarts()
+    {
+        // Headline invariant for #69: Railway redeploys must not
+        // rotate JWKS, otherwise every issued token across every
+        // consumer service goes invalid simultaneously.
+        string firstKid;
+        using (var factory = new ProductionWebApplicationFactory(
+            keysPath: _keysDir, useEphemeralKeys: false, dbPath: _dbPath))
+        using (var client = HttpsClient(factory))
+        {
+            firstKid = await GetFirstJwksKidAsync(client);
+        }
+
+        string secondKid;
+        using (var factory = new ProductionWebApplicationFactory(
+            keysPath: _keysDir, useEphemeralKeys: false, dbPath: _dbPath))
+        using (var client = HttpsClient(factory))
+        {
+            secondKid = await GetFirstJwksKidAsync(client);
+        }
+
+        secondKid.Should().Be(
+            firstKid,
+            "Production with OpenIddict:SigningKeys:Path must keep JWKS " +
+            "stable across redeploys; otherwise every issued JWT goes " +
+            "invalid on container restart");
+    }
+
+    [Fact]
+    public async Task ProductionBoot_WithEphemeralKeys_ServesJwks()
+    {
+        // Stateless-pod fallback: ephemeral keys are explicitly opted in.
+        // Boot must succeed; JWKS must be served. The keys WILL rotate on
+        // every restart (the documented trade-off) — not asserted here.
+        using var factory = new ProductionWebApplicationFactory(
+            keysPath: null, useEphemeralKeys: true, dbPath: _dbPath);
+        using var client = HttpsClient(factory);
+
+        var response = await client.GetAsync("/.well-known/openid-configuration");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var jwksUri = doc.RootElement.GetProperty("jwks_uri").GetString();
+        jwksUri.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void ProductionBoot_WithoutKeysPathOrEphemeralFlag_ThrowsOnStartup()
+    {
+        var factory = new ProductionWebApplicationFactory(
+            keysPath: null, useEphemeralKeys: false, dbPath: _dbPath);
+
+        var act = () =>
+        {
+            using var _ = factory.CreateClient();
+        };
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*OpenIddict:SigningKeys:Path*UseEphemeralKeys*");
+
+        factory.Dispose();
+    }
+
+    // Production keeps OpenIddict's HTTPS-only requirement (the
+    // Embedded-mode `DisableTransportSecurityRequirement()` does not
+    // apply here), so the in-memory test client must speak `https://`
+    // to satisfy `Request.IsHttps == true` in the OpenIddict pipeline.
+    // TestServer fakes both schemes — there is no real TLS handshake.
+    private static HttpClient HttpsClient(WebApplicationFactory<Program> factory)
+    {
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("https://localhost/")
+        });
+        return client;
+    }
+
+    private static async Task<string> GetFirstJwksKidAsync(HttpClient client)
+    {
+        var discovery = await client.GetAsync("/.well-known/openid-configuration");
+        discovery.StatusCode.Should().Be(HttpStatusCode.OK);
+        var discoveryJson = await discovery.Content.ReadAsStringAsync();
+        using var discoveryDoc = JsonDocument.Parse(discoveryJson);
+        var jwksUri = discoveryDoc.RootElement.GetProperty("jwks_uri").GetString();
+        jwksUri.Should().NotBeNullOrEmpty();
+
+        var uri = new Uri(jwksUri!);
+        var relative = uri.AbsolutePath + uri.Query;
+
+        var jwks = await client.GetAsync(relative);
+        jwks.StatusCode.Should().Be(HttpStatusCode.OK);
+        var jwksJson = await jwks.Content.ReadAsStringAsync();
+        using var jwksDoc = JsonDocument.Parse(jwksJson);
+        var keys = jwksDoc.RootElement.GetProperty("keys");
+        keys.GetArrayLength().Should().BeGreaterThan(0);
+        return keys[0].GetProperty("kid").GetString()!;
+    }
+
+    // Same env-var injection trick as EmbeddedWebApplicationFactory —
+    // Program.cs reads config before the factory's callbacks run, so
+    // we drive Production config via environment variables.
+    private sealed class ProductionWebApplicationFactory : WebApplicationFactory<Program>
+    {
+        private readonly Dictionary<string, string?> _priorEnvValues = new();
+
+        public ProductionWebApplicationFactory(string? keysPath, bool useEphemeralKeys, string dbPath)
+        {
+            SetEnv("ASPNETCORE_ENVIRONMENT", "Production");
+            SetEnv("OpenIddict__Issuer", "https://auth.example.test/");
+            SetEnv("Database__Provider", "Sqlite");
+            SetEnv("ConnectionStrings__Sqlite", $"Data Source={dbPath}");
+            SetEnv("ConnectionStrings__DefaultConnection", $"Data Source={dbPath}");
+            SetEnv("OpenIddict__SigningKeys__Path", keysPath);
+            SetEnv("OpenIddict__UseEphemeralKeys", useEphemeralKeys ? "true" : "false");
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Production");
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                foreach (var (key, value) in _priorEnvValues)
+                {
+                    Environment.SetEnvironmentVariable(key, value);
+                }
+            }
+            base.Dispose(disposing);
+        }
+
+        private void SetEnv(string key, string? value)
+        {
+            _priorEnvValues[key] = Environment.GetEnvironmentVariable(key);
+            Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #69. Wires `OpenIddict:SigningKeys:Path` through the Production branch of `Program.cs` so the deploy story #59 (E3-S4 — Railway volume at `/data/keys`) becomes implementable. JWKS `kid` now survives a redeploy → no more cascade-invalidation of every cached JWT across every consumer service on container restart.

Reuses the existing `PersistedDevelopmentKeys` helper (same RSA PEM-on-disk mechanism Embedded mode uses) — different host trust boundary, same code path.

## Production branch behaviour

| `OpenIddict:SigningKeys:Path` | `OpenIddict:UseEphemeralKeys` | Outcome |
|---|---|---|
| set | (ignored) | Persisted RSA keys at the path. JWKS stable across restart. |
| unset | `true` | Ephemeral keys (Railway-pod fallback). Keys rotate on every restart. |
| unset | `false` (or absent) | **Hard-fail boot** with a message that documents both options. |

Embedded and Development branches are unchanged.

## Test plan

- [x] New `ProductionModeIntegrationTests` (4 tests) mirrors `EmbeddedModeIntegrationTests`:
  - keys persist to disk
  - JWKS `kid` stable across factory restart (the headline #69 invariant)
  - ephemeral fallback serves JWKS
  - missing-config hard-fails boot with both options in the error
- [x] `dotnet test tests/Andy.Auth.Server.Tests` — **515 / 528 pass** (+4 new, same 10 pre-existing reds).
- [x] `dotnet build src/Andy.Auth.Server` — clean.

## Notes

- Deliberately did **not** add a placeholder to `appsettings.Production.json`. The existing `Issuer = "SET_VIA_ENVIRONMENT_VARIABLE"` placeholder fails loudly at boot via `new Uri(...)`. A directory-path placeholder would silently `Directory.CreateDirectory("SET_VIA_ENVIRONMENT_VARIABLE")` — fail-quiet, wrong behaviour. The `Program.cs` throw with both options listed is the documentation.
- The `PersistedDevelopmentKeys` class name is now slightly misleading (it serves Production too). Renaming to `PersistedSigningKeys` was deferred — the rename has surface area that didn't fit this PR's scope. Doc comment updated to acknowledge the dual use.
- True PFX-from-vault support (Azure Key Vault, AWS Secrets Manager) is a future story when the trust model needs to tighten beyond filesystem perms.