### PR TITLE
PersistedDevelopmentKeys: pin corruption contract + negative tests (closes #71)

### DIFF
--- a/docs/issues/persisted-keys-negative-paths.md
+++ b/docs/issues/persisted-keys-negative-paths.md
@@ -1,0 +1,70 @@
+# `PersistedDevelopmentKeys`: negative-path tests + clearer corruption errors
+
+## Problem
+
+`PersistedDevelopmentKeys.LoadOrCreate` only has happy-path test coverage:
+- generates the key on first call
+- returns the same key on second call
+- doesn't overwrite an existing file
+- produces a 2048-bit RSA usable for SignData/VerifyData
+- sets 0600 perms on Unix
+
+Three failure modes the post-merge review flagged are untested:
+
+1. **Malformed PEM** — `signing.key` exists but contents are corrupt (manual edit, fs corruption, ransomware). `RSA.ImportFromPem` throws `CryptographicException` with no context about *which* file failed; the exception bubbles up through the OpenIddict server boot and the operator sees a stack trace deep in the framework.
+
+2. **Half-write recovery** — first boot is interrupted between `WriteAllText("signing.key", …)` and `WriteAllText("encryption.key", …)`. On second boot, `signing.key` exists and loads fine; `encryption.key` is missing → regenerated. Asymmetric. Or: the file exists but is empty/truncated. Same trap as #1.
+
+3. **Unwritable directory** — `OpenIddict:SigningKeys:Path` points at a read-only mount or a directory the service account doesn't have write perms on. `Directory.CreateDirectory` succeeds (it's idempotent for existing dirs), `File.WriteAllText` then throws `UnauthorizedAccessException` / `IOException`.
+
+Silently regenerating on corruption is the wrong fix — that'd invalidate every cached JWT held by every consumer service. Hard-fail with a helpful message is the right answer; the test suite needs to pin that contract so a future "let's just regenerate" change can't slip in.
+
+## Fix
+
+### Tests
+
+Add to `tests/Andy.Auth.Server.Tests/Configuration/PersistedDevelopmentKeysTests.cs`:
+
+- `LoadOrCreate_MalformedPem_ThrowsWithFilePathInMessage`
+- `LoadOrCreate_EmptyFile_ThrowsWithFilePathInMessage`
+- `LoadOrCreate_TruncatedPem_ThrowsWithFilePathInMessage`
+- `LoadOrCreate_UnwritableDirectory_PropagatesIoException` (Unix only — Windows ACLs are different)
+
+### Helper hardening
+
+Wrap the `RSA.ImportFromPem` call in `LoadOrCreate` with a try/catch that rethrows as a more helpful exception mentioning the file path. Don't silently regenerate.
+
+```csharp
+try
+{
+    rsa.ImportFromPem(File.ReadAllText(filePath));
+    return rsa;
+}
+catch (CryptographicException inner)
+{
+    rsa.Dispose();
+    throw new InvalidOperationException(
+        $"Persisted signing/encryption key at '{filePath}' is corrupt or " +
+        $"not a valid PKCS#8 PEM keypair. Refusing to regenerate — that " +
+        $"would invalidate every issued JWT. Restore the file from backup " +
+        $"or delete it intentionally to trigger a fresh keypair.",
+        inner);
+}
+```
+
+## Acceptance criteria
+
+- [ ] Four new tests cover the three failure modes (malformed PEM, empty file, truncated PEM, unwritable dir).
+- [ ] `LoadOrCreate` wraps corruption errors with a message that includes the file path and explicitly states it will not auto-regenerate.
+- [ ] No existing test changes shape.
+- [ ] Build clean, full server suite green-or-same as `main`.
+
+## Files touched
+
+- `src/Andy.Auth.Server/Configuration/PersistedDevelopmentKeys.cs` — try/catch wrapper around `ImportFromPem`.
+- `tests/Andy.Auth.Server.Tests/Configuration/PersistedDevelopmentKeysTests.cs` — four new tests.
+
+## Notes
+
+- "Recovery" in the original review note means "graceful failure with a clear pointer to a fix", not "silent regenerate".
+- Symlink-pivot defence (`Path.GetFullPath` realpath check) is a separate hardening item — out of scope for this PR.

--- a/src/Andy.Auth.Server/Configuration/PersistedDevelopmentKeys.cs
+++ b/src/Andy.Auth.Server/Configuration/PersistedDevelopmentKeys.cs
@@ -76,8 +76,28 @@ public static class PersistedDevelopmentKeys
         var rsa = RSA.Create(2048);
         if (File.Exists(filePath))
         {
-            rsa.ImportFromPem(File.ReadAllText(filePath));
-            return rsa;
+            try
+            {
+                rsa.ImportFromPem(File.ReadAllText(filePath));
+                return rsa;
+            }
+            catch (Exception inner) when (inner is CryptographicException
+                                       || inner is ArgumentException)
+            {
+                // Corrupt / truncated / empty file. Refuse to regenerate
+                // — auto-regenerate would invalidate every previously
+                // issued JWT held by every downstream service. Surface
+                // a message that names the file and tells the operator
+                // exactly what to do.
+                rsa.Dispose();
+                throw new InvalidOperationException(
+                    $"Persisted signing/encryption key at '{filePath}' is " +
+                    $"corrupt or not a valid PKCS#8 PEM keypair. Refusing " +
+                    $"to regenerate — that would invalidate every issued " +
+                    $"JWT. Restore the file from backup, or delete it " +
+                    $"intentionally to trigger a fresh keypair.",
+                    inner);
+            }
         }
 
         File.WriteAllText(filePath, rsa.ExportPkcs8PrivateKeyPem());

--- a/tests/Andy.Auth.Server.Tests/Configuration/PersistedDevelopmentKeysTests.cs
+++ b/tests/Andy.Auth.Server.Tests/Configuration/PersistedDevelopmentKeysTests.cs
@@ -120,6 +120,94 @@ public class PersistedDevelopmentKeysTests : IDisposable
     // the OpenIddict.Server package reference in this test assembly.
 
     [Fact]
+    public void LoadOrCreate_MalformedPem_ThrowsWithFilePathInMessage()
+    {
+        // Pins the corruption contract: a garbage PEM file must not
+        // silently regenerate (regenerate = invalidate every cached
+        // JWT across every downstream service). Hard-fail with the
+        // path in the message so the operator knows what to fix.
+        var path = Path.Combine(_tempDir, "signing.key");
+        File.WriteAllText(path, "-----BEGIN PRIVATE KEY-----\nNOT-A-REAL-KEY\n-----END PRIVATE KEY-----\n");
+
+        var act = () => PersistedDevelopmentKeys.LoadOrCreate(path);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*corrupt or not a valid PKCS#8 PEM*")
+            .WithMessage($"*{path}*");
+    }
+
+    [Fact]
+    public void LoadOrCreate_EmptyFile_ThrowsWithFilePathInMessage()
+    {
+        // First-boot interrupted between File.Create and the actual
+        // PEM write leaves a zero-byte file. Same hard-fail contract
+        // — don't silently regenerate.
+        var path = Path.Combine(_tempDir, "signing.key");
+        File.WriteAllText(path, string.Empty);
+
+        var act = () => PersistedDevelopmentKeys.LoadOrCreate(path);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*corrupt or not a valid PKCS#8 PEM*")
+            .WithMessage($"*{path}*");
+    }
+
+    [Fact]
+    public void LoadOrCreate_TruncatedPem_ThrowsWithFilePathInMessage()
+    {
+        // Write a real key, then truncate it mid-base64 to simulate
+        // a partial fsync or filesystem corruption. The truncated
+        // file is not a valid keypair — must not silently regenerate.
+        var path = Path.Combine(_tempDir, "signing.key");
+        using (var seed = PersistedDevelopmentKeys.LoadOrCreate(path)) { }
+        var full = File.ReadAllText(path);
+        File.WriteAllText(path, full.Substring(0, full.Length / 2));
+
+        var act = () => PersistedDevelopmentKeys.LoadOrCreate(path);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*corrupt or not a valid PKCS#8 PEM*")
+            .WithMessage($"*{path}*");
+    }
+
+    [Fact]
+    public void LoadOrCreate_UnwritableDirectory_PropagatesIoException()
+    {
+        // OpenIddict:SigningKeys:Path pointing at a read-only mount
+        // (or a dir the service account doesn't own). Directory.CreateDirectory
+        // is idempotent for an existing dir, so the failure surfaces at
+        // File.WriteAllText. Skip on Windows — its ACL model differs.
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        var roDir = Path.Combine(_tempDir, "readonly");
+        Directory.CreateDirectory(roDir);
+        try
+        {
+            File.SetUnixFileMode(
+                roDir,
+                UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+            var path = Path.Combine(roDir, "signing.key");
+
+            var act = () => PersistedDevelopmentKeys.LoadOrCreate(path);
+
+            act.Should().Throw<UnauthorizedAccessException>(
+                "a read-only directory must surface as a permission error " +
+                "so the operator can re-mount or chmod, not silently fail");
+        }
+        finally
+        {
+            // Restore write perms so xunit can clean up _tempDir.
+            File.SetUnixFileMode(
+                roDir,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
+    [Fact]
     public void LoadOrCreate_FilePermissionsAreOwnerOnlyOnUnix()
     {
         if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())


### PR DESCRIPTION
## Summary

Closes #71. Three failure modes for the on-disk keypair were uncovered by the post-merge review:

1. **Malformed PEM** — file exists but contents corrupt (manual edit / fs corruption).
2. **Empty / truncated file** — first boot interrupted between `File.Create` and the PEM write.
3. **Unwritable directory** — `OpenIddict:SigningKeys:Path` points at a read-only mount or a directory the service account doesn't own.

Silently regenerating on corruption would be the wrong fix: auto-regenerate invalidates every cached JWT held by every downstream service. Hard-fail with a helpful, path-naming message is the right answer; this PR pins that contract in tests so a future "let's just regenerate" change can't slip in.

## Changes

- **`PersistedDevelopmentKeys.LoadOrCreate`**: wraps `RSA.ImportFromPem` in a try/catch that rethrows as `InvalidOperationException` naming the file path and stating regeneration is refused.
- **Four new tests** in `PersistedDevelopmentKeysTests.cs`:
  - malformed PEM throws with file path in message
  - empty file throws with file path in message
  - truncated PEM throws with file path in message
  - unwritable directory propagates `UnauthorizedAccessException` (Unix-only; Windows ACLs differ)

## Test plan

- [x] `dotnet test tests/Andy.Auth.Server.Tests --filter "FullyQualifiedName~PersistedDevelopmentKeysTests"` — 10/10 pass.
- [x] Full server suite: 519 / 532 pass (+4 vs main, same 10 pre-existing reds).
- [x] `dotnet build` clean.

## Notes

- No behaviour change on the happy path.
- Symlink-pivot defence (a `Path.GetFullPath` realpath check before write) is a separate hardening item — out of scope here.