### PR TITLE
Cross-mode test factory: extract EnvironmentWebApplicationFactory (closes #73)

### DIFF
--- a/docs/issues/cross-mode-test-factory.md
+++ b/docs/issues/cross-mode-test-factory.md
@@ -1,0 +1,40 @@
+# Cross-mode test factory: extract `EnvironmentWebApplicationFactory`
+
+## Problem
+
+`EmbeddedModeIntegrationTests` and `ProductionModeIntegrationTests` each carry a private inner `WebApplicationFactory<Program>` subclass (~30 lines of boilerplate each) doing the same env-var injection trick — Program.cs reads `builder.Configuration` before the factory's `ConfigureAppConfiguration` callbacks run, so config has to be set via environment variables. The two inner classes differ only in the env-var values they inject.
+
+The post-merge review's recommendation #5 ("cross-mode integration test matrix — parametrize EmbeddedWebApplicationFactory on env name") wants this consolidated. Without consolidation, each new mode-specific test class would re-paste the same boilerplate.
+
+## Fix
+
+Extract a shared `EnvironmentWebApplicationFactory` taking:
+- `environmentName` (Development / Docker / Embedded / Production / Staging / UAT)
+- `dbPath` (SQLite db path; required so DbSeeder doesn't need Postgres)
+- `issuer` (the OpenIddict:Issuer URL — Production requires non-default to override the placeholder)
+- `keysPath` (nullable; used only for Embedded + Production-with-persisted-keys)
+- `useEphemeralKeys` (bool; only meaningful for Production)
+
+Refactor `EmbeddedModeIntegrationTests` and `ProductionModeIntegrationTests` to use it. Behaviour identical, ~60 LOC of dup gone.
+
+Demonstrate the parametrization works by adding one cross-mode parity test that asserts the OIDC discovery document advertises `code_challenge_methods_supported: ["S256"]` and `issuer == configured` under three different env names (PKCE coverage already exists at the options level via `PkceEnforcementTests`, but a cross-mode end-to-end smoke is the visible value of this refactor).
+
+## Acceptance criteria
+
+- [ ] New `tests/Andy.Auth.Server.Tests/EnvironmentWebApplicationFactory.cs` exposes the constructor surface above.
+- [ ] `EmbeddedModeIntegrationTests` no longer defines a private `EmbeddedWebApplicationFactory`; uses the shared one.
+- [ ] `ProductionModeIntegrationTests` no longer defines a private `ProductionWebApplicationFactory`; uses the shared one.
+- [ ] One new mode-parity test (Theory or per-env Facts) asserts the OIDC discovery contract under each of Embedded + Production-with-keys.
+- [ ] Existing test count and pass count preserved (no regressions).
+
+## Out of scope
+
+- Full auth-code flow tests parametrized per env. The TestServer needs a pre-authenticated session to complete the auth-code flow, and the existing `OAuthIntegrationTests.ClaudeDesktopClient_AuthorizationCodeFlowWithPKCE_ShouldSucceed` already dodges the auth step. Adding auth-code completion is a much bigger lift; would warrant its own story.
+- **Docker-mode signing-key gap** (separate finding). Program.cs's `if (IsEmbedded()) { … } else if (IsDevelopment() || Staging || UAT) { … } else if (IsProduction()) { … }` doesn't match `ASPNETCORE_ENVIRONMENT=Docker` — the block is silently skipped, OpenIddict ends up with no signing/encryption keys, and any token-issuance request fails at runtime. Docker is the env name `docker-compose.yml` should set per `HostEnvironmentExtensions`'s comment, but no real deployment uses it today. To fix in a separate issue.
+
+## Files touched
+
+- `tests/Andy.Auth.Server.Tests/EnvironmentWebApplicationFactory.cs` (new)
+- `tests/Andy.Auth.Server.Tests/EmbeddedModeIntegrationTests.cs` (drops inner factory)
+- `tests/Andy.Auth.Server.Tests/ProductionModeIntegrationTests.cs` (drops inner factory)
+- `tests/Andy.Auth.Server.Tests/CrossModeDiscoveryTests.cs` (new — the parity smoke)

--- a/tests/Andy.Auth.Server.Tests/CrossModeDiscoveryTests.cs
+++ b/tests/Andy.Auth.Server.Tests/CrossModeDiscoveryTests.cs
@@ -1,0 +1,133 @@
+using System.Net;
+using System.Text.Json;
+using Andy.Auth.Server.Configuration;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Andy.Auth.Server.Tests;
+
+// Cross-mode parity smoke for the OIDC discovery contract. Each
+// supported deployment mode (Embedded, Production-with-keys,
+// Production-with-ephemeral-keys) must serve a discovery doc with
+// the configured issuer and S256 PKCE advertised — otherwise a
+// consumer service that boots in one mode would fail to validate
+// tokens minted by andy-auth in another.
+//
+// Demonstrates the value of `EnvironmentWebApplicationFactory` —
+// adding a new mode is one factory call, no boilerplate.
+public class CrossModeDiscoveryTests : IDisposable
+{
+    private readonly string _baseTemp;
+
+    public CrossModeDiscoveryTests()
+    {
+        _baseTemp = Path.Combine(
+            Path.GetTempPath(),
+            "andy-auth-crossmode-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_baseTemp);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_baseTemp))
+            {
+                Directory.Delete(_baseTemp, recursive: true);
+            }
+        }
+        catch (IOException) { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    public static IEnumerable<object[]> Modes => new[]
+    {
+        new object[] { Mode.Embedded, "http://localhost:9100/auth/" },
+        new object[] { Mode.ProductionPersistedKeys, "https://auth.example.test/" },
+        new object[] { Mode.ProductionEphemeralKeys, "https://auth.example.test/" },
+    };
+
+    [Theory]
+    [MemberData(nameof(Modes))]
+    public async Task DiscoveryDoc_AdvertisesConfiguredIssuerAndPkceMethods(Mode mode, string issuer)
+    {
+        using var factory = CreateFactory(mode, issuer);
+        using var client = ClientFor(factory, mode);
+
+        var response = await client.GetAsync("/.well-known/openid-configuration");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("issuer").GetString().Should().Be(issuer,
+            "every mode must surface its configured issuer in the discovery doc");
+
+        var methods = doc.RootElement
+            .GetProperty("code_challenge_methods_supported")
+            .EnumerateArray()
+            .Select(e => e.GetString())
+            .ToList();
+        methods.Should().Contain("S256",
+            "PKCE S256 is the only accepted method server-wide (closes #46)");
+
+        doc.RootElement.GetProperty("jwks_uri").GetString()
+            .Should().NotBeNullOrEmpty("every mode must publish a jwks_uri");
+    }
+
+    private EnvironmentWebApplicationFactory CreateFactory(Mode mode, string issuer)
+    {
+        var modeDir = Path.Combine(_baseTemp, mode.ToString());
+        Directory.CreateDirectory(modeDir);
+        var dbPath = Path.Combine(modeDir, "andy-auth.sqlite");
+        var keysPath = Path.Combine(modeDir, "keys");
+
+        return mode switch
+        {
+            Mode.Embedded => new EnvironmentWebApplicationFactory(
+                environmentName: HostEnvironmentExtensions.EmbeddedEnvironmentName,
+                dbPath: dbPath,
+                issuer: issuer,
+                keysPath: keysPath),
+
+            Mode.ProductionPersistedKeys => new EnvironmentWebApplicationFactory(
+                environmentName: "Production",
+                dbPath: dbPath,
+                issuer: issuer,
+                keysPath: keysPath),
+
+            Mode.ProductionEphemeralKeys => new EnvironmentWebApplicationFactory(
+                environmentName: "Production",
+                dbPath: dbPath,
+                issuer: issuer,
+                keysPath: null,
+                useEphemeralKeys: true),
+
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+    }
+
+    private static HttpClient ClientFor(WebApplicationFactory<Program> factory, Mode mode)
+    {
+        // Embedded calls DisableTransportSecurityRequirement(); HTTP is fine.
+        // Production keeps OpenIddict's HTTPS-only requirement, so the
+        // in-memory client must speak https://. TestServer fakes both.
+        var baseAddress = mode == Mode.Embedded
+            ? new Uri("http://localhost/")
+            : new Uri("https://localhost/");
+
+        return factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = baseAddress
+        });
+    }
+
+    public enum Mode
+    {
+        Embedded,
+        ProductionPersistedKeys,
+        ProductionEphemeralKeys
+    }
+}

--- a/tests/Andy.Auth.Server.Tests/EmbeddedModeIntegrationTests.cs
+++ b/tests/Andy.Auth.Server.Tests/EmbeddedModeIntegrationTests.cs
@@ -2,9 +2,6 @@ using System.Net;
 using System.Text.Json;
 using Andy.Auth.Server.Configuration;
 using FluentAssertions;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.Configuration;
 
 namespace Andy.Auth.Server.Tests;
 
@@ -52,14 +49,15 @@ public class EmbeddedModeIntegrationTests : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    private EmbeddedWebApplicationFactory CreateFactory(
+    private EnvironmentWebApplicationFactory CreateFactory(
         string? keysPathOverride = null,
         string? issuerOverride = null)
     {
-        return new EmbeddedWebApplicationFactory(
-            keysPath: keysPathOverride ?? _keysDir,
+        return new EnvironmentWebApplicationFactory(
+            environmentName: HostEnvironmentExtensions.EmbeddedEnvironmentName,
             dbPath: _dbPath,
-            issuer: issuerOverride ?? "http://localhost:9100/auth/");
+            issuer: issuerOverride ?? "http://localhost:9100/auth/",
+            keysPath: keysPathOverride ?? _keysDir);
     }
 
     [Fact]
@@ -125,10 +123,11 @@ public class EmbeddedModeIntegrationTests : IDisposable
     [Fact]
     public void EmbeddedBoot_WithoutKeysPath_ThrowsOnStartup()
     {
-        var factory = new EmbeddedWebApplicationFactory(
-            keysPath: null,
+        var factory = new EnvironmentWebApplicationFactory(
+            environmentName: HostEnvironmentExtensions.EmbeddedEnvironmentName,
             dbPath: _dbPath,
-            issuer: "http://localhost:9100/auth/");
+            issuer: "http://localhost:9100/auth/",
+            keysPath: null);
 
         // Forcing CreateClient triggers the host build, which materialises
         // the OpenIddict server options — which is where our guard throws.
@@ -189,56 +188,4 @@ public class EmbeddedModeIntegrationTests : IDisposable
         return keys[0].GetProperty("kid").GetString()!;
     }
 
-    // Program.cs reads `builder.Configuration` during the top-level
-    // `WebApplication.CreateBuilder(args)` call, BEFORE WebApplicationFactory's
-    // `ConfigureAppConfiguration` callbacks run. Overriding the config via
-    // the factory's callback therefore cannot influence Program.cs's direct
-    // reads (e.g. `builder.Configuration["OpenIddict:Issuer"]`).
-    //
-    // The standard workaround for WebApplicationFactory + minimal hosting
-    // is to set environment variables before the factory spins up the host.
-    // ASP.NET Core's default EnvironmentVariablesConfigurationProvider maps
-    // `Key__SubKey=Value` to `Key:SubKey=Value` in config, so env vars are
-    // visible to Program.cs from the very first configuration read.
-    //
-    // Tests in this assembly run serially (xunit.runner.json sets
-    // parallelizeTestCollections=false), so global env-var state is safe
-    // to swap between tests.
-    private sealed class EmbeddedWebApplicationFactory : WebApplicationFactory<Program>
-    {
-        private readonly Dictionary<string, string?> _priorEnvValues = new();
-
-        public EmbeddedWebApplicationFactory(string? keysPath, string dbPath, string issuer)
-        {
-            SetEnv("ASPNETCORE_ENVIRONMENT", HostEnvironmentExtensions.EmbeddedEnvironmentName);
-            SetEnv("OpenIddict__Issuer", issuer);
-            SetEnv("Database__Provider", "Sqlite");
-            SetEnv("ConnectionStrings__Sqlite", $"Data Source={dbPath}");
-            SetEnv("ConnectionStrings__DefaultConnection", $"Data Source={dbPath}");
-            SetEnv("OpenIddict__SigningKeys__Path", keysPath);
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment(HostEnvironmentExtensions.EmbeddedEnvironmentName);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                foreach (var (key, value) in _priorEnvValues)
-                {
-                    Environment.SetEnvironmentVariable(key, value);
-                }
-            }
-            base.Dispose(disposing);
-        }
-
-        private void SetEnv(string key, string? value)
-        {
-            _priorEnvValues[key] = Environment.GetEnvironmentVariable(key);
-            Environment.SetEnvironmentVariable(key, value);
-        }
-    }
 }

--- a/tests/Andy.Auth.Server.Tests/EnvironmentWebApplicationFactory.cs
+++ b/tests/Andy.Auth.Server.Tests/EnvironmentWebApplicationFactory.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Andy.Auth.Server.Tests;
+
+// Shared `WebApplicationFactory<Program>` for env-driven integration
+// tests. Program.cs reads `builder.Configuration` before
+// WebApplicationFactory's `ConfigureAppConfiguration` callbacks run,
+// so config has to be set via environment variables — ASP.NET Core's
+// EnvironmentVariablesConfigurationProvider maps `Key__SubKey=Value`
+// to `Key:SubKey=Value` in config and is visible from the very first
+// configuration read.
+//
+// Tests in this assembly run serially (xunit.runner.json sets
+// parallelizeTestCollections=false and parallelizeAssembly=false),
+// so the shared environment-variable mutation is safe between tests.
+//
+// Constructor parameters:
+//   environmentName   ASPNETCORE_ENVIRONMENT (Development / Docker /
+//                     Embedded / Production / Staging / UAT).
+//   dbPath            SQLite path so DbSeeder doesn't require Postgres.
+//   issuer            OpenIddict:Issuer URL. Production's appsettings
+//                     ships a `SET_VIA_ENVIRONMENT_VARIABLE` placeholder
+//                     that crashes `new Uri(…)` unless overridden here.
+//   keysPath          Nullable. Used by Embedded mode and by
+//                     Production with persisted keys.
+//   useEphemeralKeys  Only meaningful for Production. Ignored elsewhere.
+internal sealed class EnvironmentWebApplicationFactory : WebApplicationFactory<Program>
+{
+    private readonly Dictionary<string, string?> _priorEnvValues = new();
+    private readonly string _environmentName;
+
+    public EnvironmentWebApplicationFactory(
+        string environmentName,
+        string dbPath,
+        string issuer,
+        string? keysPath = null,
+        bool useEphemeralKeys = false)
+    {
+        _environmentName = environmentName;
+        SetEnv("ASPNETCORE_ENVIRONMENT", environmentName);
+        SetEnv("OpenIddict__Issuer", issuer);
+        SetEnv("Database__Provider", "Sqlite");
+        SetEnv("ConnectionStrings__Sqlite", $"Data Source={dbPath}");
+        SetEnv("ConnectionStrings__DefaultConnection", $"Data Source={dbPath}");
+        SetEnv("OpenIddict__SigningKeys__Path", keysPath);
+        SetEnv("OpenIddict__UseEphemeralKeys", useEphemeralKeys ? "true" : "false");
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment(_environmentName);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            foreach (var (key, value) in _priorEnvValues)
+            {
+                Environment.SetEnvironmentVariable(key, value);
+            }
+        }
+        base.Dispose(disposing);
+    }
+
+    private void SetEnv(string key, string? value)
+    {
+        _priorEnvValues[key] = Environment.GetEnvironmentVariable(key);
+        Environment.SetEnvironmentVariable(key, value);
+    }
+}

--- a/tests/Andy.Auth.Server.Tests/ProductionModeIntegrationTests.cs
+++ b/tests/Andy.Auth.Server.Tests/ProductionModeIntegrationTests.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Text.Json;
 using FluentAssertions;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 
@@ -50,10 +49,7 @@ public class ProductionModeIntegrationTests : IDisposable
     [Fact]
     public async Task ProductionBoot_WithKeysPath_PersistsKeysToDisk()
     {
-        using var factory = new ProductionWebApplicationFactory(
-            keysPath: _keysDir,
-            useEphemeralKeys: false,
-            dbPath: _dbPath);
+        using var factory = ProductionFactory(keysPath: _keysDir, useEphemeralKeys: false);
         using var client = HttpsClient(factory);
 
         var response = await client.GetAsync("/.well-known/openid-configuration");
@@ -70,16 +66,14 @@ public class ProductionModeIntegrationTests : IDisposable
         // rotate JWKS, otherwise every issued token across every
         // consumer service goes invalid simultaneously.
         string firstKid;
-        using (var factory = new ProductionWebApplicationFactory(
-            keysPath: _keysDir, useEphemeralKeys: false, dbPath: _dbPath))
+        using (var factory = ProductionFactory(keysPath: _keysDir, useEphemeralKeys: false))
         using (var client = HttpsClient(factory))
         {
             firstKid = await GetFirstJwksKidAsync(client);
         }
 
         string secondKid;
-        using (var factory = new ProductionWebApplicationFactory(
-            keysPath: _keysDir, useEphemeralKeys: false, dbPath: _dbPath))
+        using (var factory = ProductionFactory(keysPath: _keysDir, useEphemeralKeys: false))
         using (var client = HttpsClient(factory))
         {
             secondKid = await GetFirstJwksKidAsync(client);
@@ -98,8 +92,7 @@ public class ProductionModeIntegrationTests : IDisposable
         // Stateless-pod fallback: ephemeral keys are explicitly opted in.
         // Boot must succeed; JWKS must be served. The keys WILL rotate on
         // every restart (the documented trade-off) — not asserted here.
-        using var factory = new ProductionWebApplicationFactory(
-            keysPath: null, useEphemeralKeys: true, dbPath: _dbPath);
+        using var factory = ProductionFactory(keysPath: null, useEphemeralKeys: true);
         using var client = HttpsClient(factory);
 
         var response = await client.GetAsync("/.well-known/openid-configuration");
@@ -114,8 +107,7 @@ public class ProductionModeIntegrationTests : IDisposable
     [Fact]
     public void ProductionBoot_WithoutKeysPathOrEphemeralFlag_ThrowsOnStartup()
     {
-        var factory = new ProductionWebApplicationFactory(
-            keysPath: null, useEphemeralKeys: false, dbPath: _dbPath);
+        var factory = ProductionFactory(keysPath: null, useEphemeralKeys: false);
 
         var act = () =>
         {
@@ -164,45 +156,13 @@ public class ProductionModeIntegrationTests : IDisposable
         return keys[0].GetProperty("kid").GetString()!;
     }
 
-    // Same env-var injection trick as EmbeddedWebApplicationFactory —
-    // Program.cs reads config before the factory's callbacks run, so
-    // we drive Production config via environment variables.
-    private sealed class ProductionWebApplicationFactory : WebApplicationFactory<Program>
+    private EnvironmentWebApplicationFactory ProductionFactory(string? keysPath, bool useEphemeralKeys)
     {
-        private readonly Dictionary<string, string?> _priorEnvValues = new();
-
-        public ProductionWebApplicationFactory(string? keysPath, bool useEphemeralKeys, string dbPath)
-        {
-            SetEnv("ASPNETCORE_ENVIRONMENT", "Production");
-            SetEnv("OpenIddict__Issuer", "https://auth.example.test/");
-            SetEnv("Database__Provider", "Sqlite");
-            SetEnv("ConnectionStrings__Sqlite", $"Data Source={dbPath}");
-            SetEnv("ConnectionStrings__DefaultConnection", $"Data Source={dbPath}");
-            SetEnv("OpenIddict__SigningKeys__Path", keysPath);
-            SetEnv("OpenIddict__UseEphemeralKeys", useEphemeralKeys ? "true" : "false");
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Production");
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                foreach (var (key, value) in _priorEnvValues)
-                {
-                    Environment.SetEnvironmentVariable(key, value);
-                }
-            }
-            base.Dispose(disposing);
-        }
-
-        private void SetEnv(string key, string? value)
-        {
-            _priorEnvValues[key] = Environment.GetEnvironmentVariable(key);
-            Environment.SetEnvironmentVariable(key, value);
-        }
+        return new EnvironmentWebApplicationFactory(
+            environmentName: "Production",
+            dbPath: _dbPath,
+            issuer: "https://auth.example.test/",
+            keysPath: keysPath,
+            useEphemeralKeys: useEphemeralKeys);
     }
 }


### PR DESCRIPTION
## Summary

Closes #73. Pulls the duplicated env-var-injection boilerplate out of `EmbeddedModeIntegrationTests` and `ProductionModeIntegrationTests` into a shared internal `EnvironmentWebApplicationFactory` parametrized on env name, db path, issuer, keys path, and ephemeral flag. ~60 LOC of duplication gone.

Demonstrates the parametrization with a new `CrossModeDiscoveryTests` that asserts the OIDC discovery contract (configured issuer + S256 PKCE + `jwks_uri`) under three modes — Embedded, Production-with-persisted-keys, Production-with-ephemeral-keys — via a single `[Theory]`. Adding a fourth mode is now one factory call.

## Test plan

- [x] All 12 mode tests pass (5 Embedded + 4 Production + 3 new cross-mode parity).
- [x] Full server suite: **522 / 535 pass** (+3 vs main, same 10 pre-existing reds).
- [x] `dotnet build` clean.

## Out of scope (intentional)

- **Full auth-code flow per mode.** The TestServer needs a pre-authenticated session to complete the flow; the existing `ClaudeDesktopClient_AuthorizationCodeFlowWithPKCE_ShouldSucceed` already dodges the auth step. Adding it is a bigger lift; separate story.
- **Docker-mode signing-key gap** (separate finding). `Program.cs`'s `if (IsEmbedded()) { … } else if (IsDevelopment() || Staging || UAT) { … } else if (IsProduction()) { … }` doesn't match `ASPNETCORE_ENVIRONMENT=Docker` — OpenIddict ends up with no signing/encryption keys configured. The block silently falls through. No real deployment uses `Docker` as the env name today, but the comment in `HostEnvironmentExtensions` says it should. Worth its own issue.