### PR TITLE
Docker mode: add to local-development signing-keys branch (closes #75)

### DIFF
--- a/docs/issues/docker-mode-signing-keys.md
+++ b/docs/issues/docker-mode-signing-keys.md
@@ -1,0 +1,47 @@
+# Docker mode: silently fails to configure OpenIddict signing keys
+
+## Problem
+
+`Program.cs:188-235` configures OpenIddict signing/encryption keys with this branching:
+
+```csharp
+if (builder.Environment.IsEmbedded()) { /* persisted RSA */ }
+else if (builder.Environment.IsDevelopment() || IsEnvironment("Staging") || IsEnvironment("UAT")) { /* ephemeral */ }
+else if (builder.Environment.IsProduction()) { /* persisted or ephemeral */ }
+```
+
+`ASPNETCORE_ENVIRONMENT=Docker` matches **none** of those — `IsDevelopment()` returns false, `IsProduction()` returns false, and `IsEmbedded()` returns false. The whole block is silently skipped. OpenIddict ends up with no signing/encryption keys configured. Boot succeeds; `/connect/token` and JWKS endpoint requests fail at runtime.
+
+`docker-compose.yml:29` currently sets `ASPNETCORE_ENVIRONMENT=Development`, so the bug is masked in practice. But:
+
+- `Configuration/HostEnvironmentExtensions.cs` declares `DockerEnvironmentName = "Docker"` and an `IsDocker()` helper — explicitly an expected mode.
+- The class doc comment lists Docker as one of three deployment modes alongside Development and Embedded.
+- A reader expecting "the three modes work" would set `ENV=Docker` and hit a silent runtime failure with no obvious diagnostic.
+
+## Fix
+
+Add `|| builder.Environment.IsDocker()` to the existing Development/Staging/UAT branch. Docker compose stacks share the trust model of local development (ephemeral keys are fine — devs re-auth on container respin), and the `IsLocalOrEmbedded()` / transport-security / HTTPS-redirect code paths already treat any non-Production env as local.
+
+```csharp
+else if (builder.Environment.IsDevelopment() ||
+         builder.Environment.IsDocker() ||
+         builder.Environment.IsEnvironment("Staging") ||
+         builder.Environment.IsEnvironment("UAT"))
+```
+
+## Acceptance criteria
+
+- [ ] `ASPNETCORE_ENVIRONMENT=Docker` boots without throwing and serves a valid JWKS doc.
+- [ ] One new test in `CrossModeDiscoveryTests` (or a dedicated `DockerModeIntegrationTests`) boots Docker env via `EnvironmentWebApplicationFactory` and asserts the discovery doc + jwks endpoint return 200.
+- [ ] `docker-compose.yml` is **not** changed in this PR. Switching the compose file to `ASPNETCORE_ENVIRONMENT=Docker` is a separate decision (it would also surface the missing `appsettings.Docker.json` and the Swagger-gating-on-IsDevelopment trade-off).
+
+## Out of scope
+
+- Creating `appsettings.Docker.json` (CORS allowlist, ports, etc.). compose still uses Development, so the existing appsettings inheritance works.
+- Switching compose to `ENV=Docker`. Same reason.
+- Symlink-pivot defence on the keys path. Separate hardening item.
+
+## Files touched
+
+- `src/Andy.Auth.Server/Program.cs` — add `IsDocker()` to the keys-block conditional.
+- `tests/Andy.Auth.Server.Tests/CrossModeDiscoveryTests.cs` — add Docker as a Theory case.

--- a/src/Andy.Auth.Server/Program.cs
+++ b/src/Andy.Auth.Server/Program.cs
@@ -210,11 +210,18 @@ builder.Services.AddOpenIddict()
             options.AddPersistedDevelopmentKeys(keysPath)
                    .DisableAccessTokenEncryption();
         }
-        else if (builder.Environment.IsDevelopment() || builder.Environment.IsEnvironment("Staging") || builder.Environment.IsEnvironment("UAT"))
+        else if (builder.Environment.IsDevelopment()
+                 || builder.Environment.IsDocker()
+                 || builder.Environment.IsEnvironment("Staging")
+                 || builder.Environment.IsEnvironment("UAT"))
         {
+            // Local-development trust model — devs (or compose-stack
+            // consumers) can re-auth on every container respin, so
+            // ephemeral keys are fine. Access tokens stay as signed
+            // JWT (industry standard); ID tokens remain encrypted.
             options.AddEphemeralEncryptionKey()
                    .AddEphemeralSigningKey()
-                   .DisableAccessTokenEncryption();  // Access tokens are signed JWT (industry standard), ID tokens remain encrypted
+                   .DisableAccessTokenEncryption();
         }
         else if (builder.Environment.IsProduction())
         {

--- a/tests/Andy.Auth.Server.Tests/CrossModeDiscoveryTests.cs
+++ b/tests/Andy.Auth.Server.Tests/CrossModeDiscoveryTests.cs
@@ -44,6 +44,7 @@ public class CrossModeDiscoveryTests : IDisposable
     public static IEnumerable<object[]> Modes => new[]
     {
         new object[] { Mode.Embedded, "http://localhost:9100/auth/" },
+        new object[] { Mode.Docker, "https://localhost:7001/" },
         new object[] { Mode.ProductionPersistedKeys, "https://auth.example.test/" },
         new object[] { Mode.ProductionEphemeralKeys, "https://auth.example.test/" },
     };
@@ -91,6 +92,11 @@ public class CrossModeDiscoveryTests : IDisposable
                 issuer: issuer,
                 keysPath: keysPath),
 
+            Mode.Docker => new EnvironmentWebApplicationFactory(
+                environmentName: HostEnvironmentExtensions.DockerEnvironmentName,
+                dbPath: dbPath,
+                issuer: issuer),
+
             Mode.ProductionPersistedKeys => new EnvironmentWebApplicationFactory(
                 environmentName: "Production",
                 dbPath: dbPath,
@@ -110,10 +116,11 @@ public class CrossModeDiscoveryTests : IDisposable
 
     private static HttpClient ClientFor(WebApplicationFactory<Program> factory, Mode mode)
     {
-        // Embedded calls DisableTransportSecurityRequirement(); HTTP is fine.
-        // Production keeps OpenIddict's HTTPS-only requirement, so the
-        // in-memory client must speak https://. TestServer fakes both.
-        var baseAddress = mode == Mode.Embedded
+        // Embedded + Docker call DisableTransportSecurityRequirement()
+        // (gated on IsLocalOrEmbedded). Production keeps OpenIddict's
+        // HTTPS-only requirement, so its in-memory client must speak
+        // https://. TestServer fakes both schemes — no real handshake.
+        var baseAddress = mode is Mode.Embedded or Mode.Docker
             ? new Uri("http://localhost/")
             : new Uri("https://localhost/");
 
@@ -127,6 +134,7 @@ public class CrossModeDiscoveryTests : IDisposable
     public enum Mode
     {
         Embedded,
+        Docker,
         ProductionPersistedKeys,
         ProductionEphemeralKeys
     }


### PR DESCRIPTION
## Summary

Closes #75. Plugs a silent boot-time bug: `ASPNETCORE_ENVIRONMENT=Docker` matched none of the `if/else if` branches in `Program.cs`'s signing-key block, so OpenIddict ended up with no signing or encryption keys configured. Boot succeeded; token issuance and JWKS failed at runtime with no obvious diagnostic.

`docker-compose.yml` currently sets `ASPNETCORE_ENVIRONMENT=Development`, so the bug was masked in practice — but `HostEnvironmentExtensions` declares Docker as one of three documented deployment modes.

Fix: add `|| builder.Environment.IsDocker()` to the existing Development/Staging/UAT branch. Docker compose stacks share the local-development trust model — devs re-auth on container respin, ephemeral keys are fine. `IsLocalOrEmbedded()` already covers Docker for the transport-security guard, so no other code paths need touching.

## Test plan

- [x] `CrossModeDiscoveryTests` gains a Docker case in its `[Theory]` (4/4 pass).
- [x] Full server suite: **523 / 536 pass** (+1 vs main, same 10 pre-existing reds).
- [x] `dotnet build` clean.

## Out of scope

- **Switching `docker-compose.yml` to `ENV=Docker`.** That would surface the missing `appsettings.Docker.json` and the Swagger-gated-on-IsDevelopment trade-off — separate decision.
- **Creating `appsettings.Docker.json`** (CORS, ports). Same reason.