### PR TITLE
HostEnvironmentExtensions: align doc comment with reality (closes #77)

### DIFF
--- a/docs/issues/host-environment-comment-accuracy.md
+++ b/docs/issues/host-environment-comment-accuracy.md
@@ -1,0 +1,43 @@
+# `HostEnvironmentExtensions` doc comment: align with reality
+
+## Context
+
+The post-merge review of 5776dc1 flagged this as the last open item: "the `appsettings.Embedded.json` decision". On closer inspection, Embedded's bullet in `HostEnvironmentExtensions.cs:18-23` is **correct** ("All configuration is injected by Conductor at process start — no static appsettings file for this environment"). The actual mismatch is in the **Docker** bullet.
+
+## Problem
+
+`Configuration/HostEnvironmentExtensions.cs:14-16` says:
+
+> Docker (ASPNETCORE_ENVIRONMENT=Docker): docker-compose stack. Ports offset +2000 from Development so both can coexist on one machine. **Config comes from appsettings.Docker.json + compose env.**
+
+That last sentence is wrong on two counts:
+
+1. **`appsettings.Docker.json` does not exist** in the repo. Docker mode is env-var driven (compose env vars), same as Embedded.
+2. **`docker-compose.yml` currently sets `ASPNETCORE_ENVIRONMENT=Development`**, not `Docker`. The bug that #75/#76 just plugged was that `ENV=Docker` silently failed; now `ENV=Docker` works, but compose still uses `Development`.
+
+The "three modes, three appsettings" mental model the comment implies doesn't match the codebase.
+
+## Fix
+
+Rewrite the Docker bullet to describe what's actually true after #76 landed:
+
+- Docker is env-var driven (no static appsettings file).
+- `docker-compose.yml` today sets `ENV=Development`; `ENV=Docker` is supported as of #76 but not yet adopted by the compose file.
+- Trust model is local-development (ephemeral keys, transport security off).
+
+Also tweak the lead-in line to drop "every Andy service" — this file is andy-auth-specific, the canonical contract lives in `andy-service-template/docs/ports.md`.
+
+## Acceptance criteria
+
+- [ ] Docker bullet describes env-var-driven config + the current compose state honestly.
+- [ ] No claim that `appsettings.Docker.json` or `appsettings.Embedded.json` exist.
+- [ ] Lead-in line acknowledges this file is the andy-auth copy of a contract, not the contract itself.
+
+## Out of scope
+
+- Creating `appsettings.Docker.json`. compose still uses Development; that decision belongs with whoever owns the deploy story.
+- Switching compose to `ENV=Docker`. Same — bigger decision, surfaces Swagger gating.
+
+## Files touched
+
+- `src/Andy.Auth.Server/Configuration/HostEnvironmentExtensions.cs` — comment-only.

--- a/src/Andy.Auth.Server/Configuration/HostEnvironmentExtensions.cs
+++ b/src/Andy.Auth.Server/Configuration/HostEnvironmentExtensions.cs
@@ -2,18 +2,24 @@ using Microsoft.Extensions.Hosting;
 
 namespace Andy.Auth.Server.Configuration;
 
-// Named accessors for the three deployment modes every Andy service
-// supports. See andy-service-template/docs/ports.md for the canonical
-// description of the modes and their port ranges.
+// Named accessors for the three deployment modes andy-auth supports.
+// The canonical description of the contract — modes, port ranges,
+// trust model — lives in `andy-service-template/docs/ports.md`. This
+// file is the andy-auth copy of the runtime predicates only.
 //
 // - Development (ASPNETCORE_ENVIRONMENT=Development): `dotnet run` on
 //   the host. Liberal defaults — Swagger, developer exception pages,
 //   SSL validation bypass, RBAC bypass — intended for a developer
-//   iterating on the service directly in their shell.
+//   iterating on the service directly in their shell. Ephemeral keys.
 //
 // - Docker     (ASPNETCORE_ENVIRONMENT=Docker): docker-compose stack.
 //   Ports offset +2000 from Development so both can coexist on one
-//   machine. Config comes from appsettings.Docker.json + compose env.
+//   machine. Config is env-var driven (no static appsettings.Docker.json
+//   today; compose env vars supply everything Program.cs reads).
+//   Local-development trust model — ephemeral keys, transport security
+//   off — same as Development. Note: docker-compose.yml currently sets
+//   ENV=Development; ENV=Docker is wired up and works (closes #75) but
+//   not yet adopted by the compose file.
 //
 // - Embedded   (ASPNETCORE_ENVIRONMENT=Embedded): bundled inside the
 //   Conductor desktop app behind a unified proxy on port 9100. All


### PR DESCRIPTION
## Summary

Closes #77 — the last open item from the post-merge review of 5776dc1.

The original review note framed this as "the `appsettings.Embedded.json` decision". Closer reading: Embedded's bullet was correct already ("all configuration is injected by Conductor at process start — no static appsettings file"). The actual mismatch was the **Docker** bullet, which claimed "Config comes from `appsettings.Docker.json` + compose env" — that file doesn't exist and `docker-compose.yml` sets `ENV=Development` anyway.

Rewrites the Docker bullet honestly: env-var driven, no static file, `ENV=Docker` is wired up post-#76 but compose hasn't switched yet. Also tweaks the lead-in to acknowledge this file is the andy-auth copy of a contract whose canonical description lives in `andy-service-template/docs/ports.md`.

## Test plan

- Comment-only — no behaviour change. `dotnet build` clean.