### PR TITLE
Register urn:andy-mcp-proxy-api as an OpenIddict resource

### DIFF
--- a/src/Andy.Auth.Server/appsettings.Development.json
+++ b/src/Andy.Auth.Server/appsettings.Development.json
@@ -45,7 +45,8 @@
       "https://localhost:5410/mcp",
       "https://localhost:5420/mcp",
       "https://localhost:5430/mcp",
-      "https://localhost:5510/mcp"
+      "https://localhost:5510/mcp",
+      "urn:andy-mcp-proxy-api"
     ],
     "Server": {
       "EncryptionKey": "Xjdvl3Z64LGdyc0XjCHyx7L23aJV7UK6AoXBaBFgTkU=",


### PR DESCRIPTION
## Summary
- Appends \`urn:andy-mcp-proxy-api\` to \`OpenIddict.Resources\` in \`src/Andy.Auth.Server/appsettings.Development.json\` so the andy-mcp-proxy audience is discoverable and can be requested as an OAuth resource indicator.
- CORS for the proxy's Angular client (\`https://localhost:4209\`, \`http://localhost:4209\`, \`https://localhost:6209\`, \`http://localhost:6209\`) and the Conductor proxy origin (\`http://localhost:9100\`) is already present in \`CorsOrigins:AllowedOrigins\` — verified, no changes needed.

Refs rivoli-ai/andy-mcp-proxy#4.

## Test plan
- [x] JSON parses (file diff is a single-line append inside the existing array)
- [ ] CI green
- [ ] After merge: from andy-mcp-proxy's integration tests, request a token with \`audience=urn:andy-mcp-proxy-api\` and assert success + JWT \`aud\` claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)