### PR TITLE
ci: install Playwright chromium before running tests

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -47,6 +47,15 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore
 
+    # The Microsoft.Playwright NuGet drops a playwright.ps1 install
+    # script into the test project's bin folder at build time. CI needs
+    # to run it once so the chromium headless_shell binary is present
+    # before the E2E suite spins up a browser. Without this every test
+    # in Andy.Auth.E2E.Tests fails immediately with
+    # `Executable doesn't exist at /home/runner/.cache/ms-playwright/...`.
+    - name: Install Playwright browsers
+      run: pwsh tests/Andy.Auth.E2E.Tests/bin/Release/net8.0/playwright.ps1 install --with-deps chromium
+
     - name: Test
       run: dotnet test --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage"
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,11 @@ jobs:
     - name: Build
       run: dotnet build --no-restore --configuration Release
 
+    # See build-and-release.yml for the rationale: the chromium binary
+    # has to be installed before the E2E suite runs.
+    - name: Install Playwright browsers
+      run: pwsh tests/Andy.Auth.E2E.Tests/bin/Release/net8.0/playwright.ps1 install --with-deps chromium
+
     - name: Test
       run: dotnet test --no-build --configuration Release --verbosity normal
       env:


### PR DESCRIPTION
## Summary

Recovers **60** failing E2E tests in CI. The `Microsoft.Playwright` NuGet emits a `playwright.ps1` install script into the test project's bin folder at build time; CI needs to run it once after Build and before Test so the chromium `headless_shell` binary is on disk when the E2E suite spins up its first browser. Without it every `Andy.Auth.E2E.Tests` case fails immediately with:

```
Microsoft.Playwright.PlaywrightException :
    Executable doesn't exist at
    /home/runner/.cache/ms-playwright/chromium_headless_shell-1148/chrome-linux/headless_shell
```

Applied to both `build-and-release.yml` (main) and `build.yml` (develop).

The remaining **11 server-test failures** in CI land in follow-up PRs:
- 6× `SessionTrackingMiddlewareTests` — `IAuthenticationService` not registered in test DI
- 3× `OAuthIntegrationTests` (ClientCredentials / TokenIntrospection / TokenRevocation) — client-secret mismatch in CI
- 1× `AdminControllerTests.Index_ReturnsViewWithStats` — uses `dynamic.Should()` (FluentAssertions not referenced)
- 1× `DcrServiceTests` IPv6 loopback parameterised case for `http://[::1]:8080/callback`

## Test plan
- [x] Workflow YAML parses (verified locally)
- [ ] CI green on this PR — same baseline minus 60 E2E failures (i.e. 11 pre-existing server-test failures still present, addressed in follow-ups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)