### PR TITLE
fix(tests): cast ViewBag.Stats to object before Should() in AdminControllerTests

### DIFF
--- a/tests/Andy.Auth.Server.Tests/AdminControllerTests.cs
+++ b/tests/Andy.Auth.Server.Tests/AdminControllerTests.cs
@@ -103,7 +103,12 @@ public class AdminControllerTests : IDisposable
 
         // Assert
         var viewResult = result.Should().BeOfType<ViewResult>().Subject;
-        _controller.ViewBag.Stats.Should().NotBeNull();
+        // ViewBag is `dynamic`, so calling FluentAssertions' Should()
+        // extension on it goes through the dynamic dispatcher and
+        // throws RuntimeBinderException because extension methods
+        // can't be resolved on `dynamic` at compile time. Cast to
+        // `object?` to pin the type before asserting.
+        ((object?)_controller.ViewBag.Stats).Should().NotBeNull();
     }
 
     // ==================== SuspendUser Tests ====================


### PR DESCRIPTION
## Summary

Recovers `AdminControllerTests.Index_ReturnsViewWithStats` — the only failing case for that test class — which was throwing in CI:

```
Microsoft.CSharp.RuntimeBinder.RuntimeBinderException :
'<>f__AnonymousType…' does not contain a definition for 'Should'
```

`ViewBag` is `dynamic` (`DynamicViewData`), so `.Stats` returns `dynamic` too. FluentAssertions' `Should()` is an extension method, and extension methods can't be resolved on `dynamic` at compile time — the dynamic dispatcher hunts for `Should` as an instance method on the runtime type and finds nothing.

Cast to `object?` first to pin the static type so the extension method binds normally. Inline comment explains the trap so future tests in this file don't repeat it.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~Index_ReturnsViewWithStats"` — passes
- [ ] CI green (drops 1 from the 5 remaining server-test failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)