### PR TITLE
fix(dcr): treat IPv6 loopback [::1] as a localhost redirect URI

### DIFF
--- a/src/Andy.Auth.Server/Services/DcrService.cs
+++ b/src/Andy.Auth.Server/Services/DcrService.cs
@@ -207,8 +207,12 @@ public class DcrService
             });
         }
 
-        // Check for localhost
-        var isLocalhost = parsedUri.Host == "localhost" || parsedUri.Host == "127.0.0.1" || parsedUri.Host == "::1";
+        // Check for localhost. Uri.IsLoopback is the canonical .NET
+        // check — it handles "localhost", "127.0.0.0/8", and "[::1]"
+        // uniformly. The previous string compare on parsedUri.Host
+        // missed IPv6 because Host returns the bracketed form ("[::1]"),
+        // never the bare "::1" we were comparing against.
+        var isLocalhost = parsedUri.IsLoopback;
 
         // Check for custom URI schemes (native app callbacks like vscode://, cursor://, etc.)
         var isCustomScheme = parsedUri.Scheme != "http" && parsedUri.Scheme != "https";


### PR DESCRIPTION
## Summary

Recovers the last failing server-side test in CI: `DcrServiceTests.ValidateRedirectUri_LoopbackAddresses_TreatedAsLocalhost(uri: "http://[::1]:8080/callback")`.

### Bug

`ValidateRedirectUri` compared `parsedUri.Host` against the literal strings `"localhost"`, `"127.0.0.1"`, and `"::1"` — but `System.Uri` returns the **bracketed** form for IPv6 hosts (`parsedUri.Host == "[::1]"` for the URI above). The bare `"::1"` comparison never matched, so the IPv6 loopback was treated as a public host and rejected.

### Fix

Replace the manual string compare with `Uri.IsLoopback`, the canonical .NET check. It returns true for all three forms uniformly:
- `"localhost"`
- `"127.0.0.0/8"` (any `127.*` address)
- `"[::1]"` (IPv6 loopback)

The IPv4 test case (`http://127.0.0.1:8080/callback`) still passes because `IsLoopback` also covers it. Net effect: same behaviour for the IPv4 input, fixed behaviour for the IPv6 input. Inline comment explains the bracket-vs-bare gotcha so future edits don't regress.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~ValidateRedirectUri"` — 12/12 pass
- [ ] CI green (drops the last server-test failure; remaining 13 E2E failures are real test bugs that need separate work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)