### PR TITLE
fix(views): nullable-boxing crash in Admin/Index broke /Admin rendering

### DIFF
--- a/src/Andy.Auth.Server/Views/Admin/Index.cshtml
+++ b/src/Andy.Auth.Server/Views/Admin/Index.cshtml
@@ -67,13 +67,18 @@
                 <tbody>
                     @foreach (var login in stats.RecentLogins)
                     {
+                        // The controller filters out nulls
+                        // (.Where(u => u.LastLoginAt != null)) before
+                        // projecting, so LastLoginAt is always set
+                        // here. We can't call .HasValue / .Value via
+                        // ViewBag's dynamic dispatch — Nullable<T>
+                        // values are boxed to their underlying T (the
+                        // CLR's nullable-boxing rule), so the dynamic
+                        // binder sees System.DateTime (no .HasValue).
                         <tr>
                             <td>@login.Email</td>
                             <td>
-                                @if (login.LastLoginAt.HasValue)
-                                {
-                                    <span data-utc="@login.LastLoginAt.Value.ToString("o")" data-format="datetime"></span>
-                                }
+                                <span data-utc="@(((DateTime)login.LastLoginAt).ToString("o"))" data-format="datetime"></span>
                             </td>
                         </tr>
                     }


### PR DESCRIPTION
## Summary

`/Admin` returned 500 on every visit because of a runtime binder failure deep in the recent-logins table. **8 of the 13 remaining E2E failures** were downstream of this single bug:

- `AdminDashboardTests.AdminDashboard_HasQuickActions`
- `AdminDashboardTests.AdminDashboard_DisplaysStatistics`
- `AdminDashboardTests.AdminDashboard_ShowsRecentActivity`
- `DateFormattingTests.DateFormatting_HandlesInvalidDates`
- `DateFormattingTests.DateFormatting_HandlesEmptyString`
- `DateFormattingTests.DateFormatting_HandlesDateOnlyFormat`
- `DateFormattingTests.DateFormatting_JavaScriptFunctionExists`
- `DateFormattingTests.DateFormatting_JavaScriptFunctionWorksCorrectly`

### Bug

```
Microsoft.CSharp.RuntimeBinder.RuntimeBinderException :
  'System.DateTime' does not contain a definition for 'HasValue'
  at Views_Admin_Index.ExecuteAsync():line 73
```

`ApplicationUser.LastLoginAt` is `DateTime?`. The controller projects it through `.Where(u => u.LastLoginAt != null).Select(u => new {…})` into an anonymous type and stuffs it onto `ViewBag.Stats`. The view iterated `stats.RecentLogins` and called `.HasValue` on each `LastLoginAt` — but `ViewBag` is `dynamic`, and the CLR's nullable-boxing rule unwraps `Nullable<T>` to its underlying `T` during boxing. The dynamic binder therefore saw `System.DateTime` (no `HasValue`) and threw.

### Fix

- Drop the redundant `HasValue` check (the controller already filtered out nulls).
- Cast through `(DateTime)` so the dynamic binder picks up the `ToString` overload directly.
- Inline comment documents the boxing rule so future ViewBag usage doesn't repeat the mistake.

## Test plan
- [x] Full `DateFormatting` + `AdminDashboard` suites pass after the fix
- [x] `dotnet test tests/Andy.Auth.E2E.Tests/` — 55/60, down from 47/60
- [ ] CI green (drops 8 of the 13 remaining failures)

Tracking the remaining 5 E2E failures separately (UserManagement, PasswordChange, Logout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)