### PR TITLE
fix(security+tests): close last 5 E2E failures (logout, change password, search/create selectors)

### DIFF
--- a/src/Andy.Auth.Server/Controllers/AccountController.cs
+++ b/src/Andy.Auth.Server/Controllers/AccountController.cs
@@ -9,7 +9,14 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Andy.Auth.Server.Controllers;
 
-[AllowAnonymous]
+// Default to authenticated. Per-action [AllowAnonymous] opens the
+// pre-login surface (Login, Register, ExternalLogin, AccessDenied,
+// 2FA prompts, recovery code, TestLogin). Actions that REQUIRE an
+// authenticated session — ChangePassword, Logout — were previously
+// no-ops because [AllowAnonymous] at the class level overrode their
+// per-action [Authorize], which let anonymous callers reach those
+// endpoints. The DefaultPolicy in Program.cs already requires
+// authentication, so omitting the class-level attribute is enough.
 public class AccountController : Controller
 {
     private readonly SignInManager<ApplicationUser> _signInManager;

--- a/tests/Andy.Auth.E2E.Tests/E2ETestBase.cs
+++ b/tests/Andy.Auth.E2E.Tests/E2ETestBase.cs
@@ -104,7 +104,11 @@ public abstract class E2ETestBase : IAsyncLifetime
     /// </summary>
     protected async Task LogoutAsync()
     {
-        await NavigateToAsync("/Account/Logout");
+        // /Account/Logout is [HttpPost] only — a GET wouldn't match
+        // and would leave the user signed in. Submit the layout's
+        // logout form (rendered into every authenticated page's nav)
+        // by clicking its submit button.
+        await Page.ClickAsync("form[action='/Account/Logout'] button[type='submit']");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
     }
 

--- a/tests/Andy.Auth.E2E.Tests/UserManagementTests.cs
+++ b/tests/Andy.Auth.E2E.Tests/UserManagementTests.cs
@@ -78,8 +78,10 @@ public class UserManagementTests : E2ETestBase
         await Page.FillAsync("input[name='Password']", "E2ETest123!");
         await Page.FillAsync("input[name='ConfirmPassword']", "E2ETest123!");
 
-        // Submit form
-        await Page.ClickAsync("button[type='submit']");
+        // Submit form. Match by visible text so we don't accidentally
+        // click the layout's logout button (it's the first
+        // `button[type='submit']` on every page).
+        await Page.ClickAsync("button:has-text('Create User')");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         // Verify redirected to users list
@@ -111,8 +113,9 @@ public class UserManagementTests : E2ETestBase
         await Page.FillAsync("input[name='Password']", "Password123!");
         await Page.FillAsync("input[name='ConfirmPassword']", "DifferentPassword123!");
 
-        // Submit form
-        await Page.ClickAsync("button[type='submit']");
+        // Submit form. Match by visible text so we don't accidentally
+        // click the layout's logout button.
+        await Page.ClickAsync("button:has-text('Create User')");
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         // Should still be on create page with error
@@ -167,16 +170,12 @@ public class UserManagementTests : E2ETestBase
             // Enter search term
             await searchInput.FillAsync("admin");
 
-            // Submit search (either via button or enter key)
-            var searchButton = await Page.QuerySelectorAsync("button[type='submit']");
-            if (searchButton != null)
-            {
-                await searchButton.ClickAsync();
-            }
-            else
-            {
-                await searchInput.PressAsync("Enter");
-            }
+            // Submit via Enter on the search input itself. A previous
+            // version of this test used `button[type='submit']`, which
+            // matched the layout's Logout button (the first submit
+            // button on the page) and logged the user out instead of
+            // running the search.
+            await searchInput.PressAsync("Enter");
 
             await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 


### PR DESCRIPTION
## Summary

Final follow-up in the andy-auth CI cleanup series. Full E2E suite now **60/60** passing. Mixes one real security fix in `AccountController` with four test-bug fixes that all hinged on selectors being too broad.

### Security fix — `AccountController` class-level `[AllowAnonymous]` overrode per-action `[Authorize]`

- Removed `[AllowAnonymous]` from the controller class.
- Per ASP.NET Core's `[Authorize]`/`[AllowAnonymous]` precedence rules, `[AllowAnonymous]` at the class level wins **unconditionally** over any `[Authorize]` applied to individual actions. `ChangePassword` (GET + POST) had `[Authorize(AuthenticationSchemes = "Identity.Application")]` but was reachable by anonymous callers because of the class-level attribute. The `[Authorize]` was effectively a no-op.
- Other actions in the controller (Login/Register/AccessDenied/2FA/Recovery/External/TestLogin/Logout) carry no `[Authorize]` of their own and rely on the absence of a `FallbackPolicy` to remain anonymous-callable. `AddAuthorization()` in `Program.cs` is called without options, so `DefaultPolicy = RequireAuthenticatedUser` (kicks in for actions WITH `[Authorize]`) but `FallbackPolicy = null` (so actions WITHOUT `[Authorize]` stay anonymous). **Net effect**: `ChangePassword` now correctly requires auth; everything else keeps its current accessibility.
- Inline comment documents the rule so future audits can see why the class attribute is intentionally omitted.

### Test fix — `LogoutAsync` was sending GET to a `[HttpPost]` endpoint

- `LogoutAsync` in `E2ETestBase` did `Page.GotoAsync("/Account/Logout")` (GET). The Logout action is `[HttpPost]`, so the GET fell through; no logout, no redirect.
- Switched to clicking the layout's logout form so the actual production POST flow is exercised end-to-end.

### Test fix — `UserManagement` tests were clicking the layout's Logout button

- Three tests used `button[type='submit']` selectors. The **first** match on every authenticated page is the layout's Logout button (earlier in DOM order than any page-specific submit), so the search/create form was never submitted — the user was logged out and redirected to `/`.
- Affects `UsersPage_CanSearchUsers`, `CreateUser_WithValidData_CreatesUser`, `CreateUser_WithMismatchedPasswords_ShowsError`.
- Switched to text-content selectors (`"button:has-text('Create User')"`) and to pressing Enter on the search input.

## Test plan
- [x] `dotnet test tests/Andy.Auth.E2E.Tests/` — 60/60 pass after this PR (was 55/60)
- [x] Server tests pass at the same count as pre-PR (local 2 failures need a real Postgres at `:7435` and are environmental)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)