### PR TITLE
feat(conductor#607): grant conductor-mac scp:urn:andy-tasks-api

### DIFF
--- a/src/Andy.Auth.Server/Data/DbSeeder.cs
+++ b/src/Andy.Auth.Server/Data/DbSeeder.cs
@@ -803,6 +803,13 @@ public class DbSeeder
                 // conductor#545 sweep.
                 "scp:urn:andy-containers-api",
                 "scp:urn:andy-rbac-api",
+                // Conductor's Andy Tasks surface (Epic T,
+                // rivoli-ai/conductor#584) calls the embedded
+                // andy-tasks service on /tasks/*; without this
+                // permission OpenIddict drops urn:andy-tasks-api
+                // from the token aud claim and andy-tasks rejects
+                // every call with IDX10214. See conductor#607.
+                "scp:urn:andy-tasks-api",
 
                 OpenIddictConstants.Permissions.ResponseTypes.Code
             },


### PR DESCRIPTION
## Summary

- Add `scp:urn:andy-tasks-api` to the `conductor-mac` OAuth client in `DbSeeder.cs`.
- Pairs with rivoli-ai/conductor#607 (T10.1, Epic T — Andy Tasks in Conductor).

Without this scope, OpenIddict silently drops `urn:andy-tasks-api` from the access-token `aud` claim emitted to Conductor, and the embedded andy-tasks service rejects every request with IDX10214.

## Test plan

- [ ] After merge, rebuild bundled binaries in Conductor (`scripts/build-all-services.sh`) and re-run `ConductorTests/EmbeddedStackSmokeTest`.
- [ ] Verify a fresh DevAutoSignIn token contains `urn:andy-tasks-api` in the `aud` array (the `DEVAUTO-AUD-MISSING-001` warning should no longer fire).

\U0001f916 Generated with [Claude Code](https://claude.com/claude-code)