### PR TITLE
Seed viewer@andy.local test user with no role bindings

### DIFF
--- a/src/Andy.Auth.Server/Data/DbSeeder.cs
+++ b/src/Andy.Auth.Server/Data/DbSeeder.cs
@@ -17,6 +17,17 @@ public class DbSeeder
     /// </summary>
     public const string TestUserWellKnownId = "00000000-0000-0000-0000-000000000001";
 
+    /// <summary>
+    /// Deterministic <c>ApplicationUser.Id</c> for <c>viewer@andy.local</c>, the
+    /// no-special-permissions counterpart to <see cref="TestUserWellKnownId"/>.
+    /// Downstream services that pre-bind roles via manifest <c>testUserRole</c>
+    /// only target <see cref="TestUserWellKnownId"/>; this viewer subject is
+    /// deliberately left unbound so consumer E2E tests have an authenticated-
+    /// but-unauthorized identity for 403 assertions. See
+    /// rivoli-ai/andy-policies#109.
+    /// </summary>
+    public const string ViewerUserWellKnownId = "00000000-0000-0000-0000-000000000002";
+
     private readonly IServiceProvider _serviceProvider;
     private readonly IConfiguration _configuration;
     private readonly ILogger<DbSeeder> _logger;
@@ -1222,6 +1233,71 @@ public class DbSeeder
                     existingTestUser.LockoutEnd = null;
                     await userManager.UpdateAsync(existingTestUser);
                     _logger.LogInformation("Cleared lockout for test user: {Email}", testEmail);
+                }
+            }
+
+            // Companion viewer user — same password as test@andy.local, deterministic Id
+            // ...000000000002, no role bindings from downstream-service manifests. Lets
+            // consumer E2E suites (e.g. rivoli-ai/andy-policies#109) drive the authenticated-
+            // but-unauthorized path without bootstrapping a user dynamically.
+            const string viewerEmail = "viewer@andy.local";
+            var existingViewer = await userManager.FindByEmailAsync(viewerEmail);
+
+            if (existingViewer == null)
+            {
+                var viewerUser = new ApplicationUser
+                {
+                    Id = ViewerUserWellKnownId,
+                    UserName = viewerEmail,
+                    Email = viewerEmail,
+                    EmailConfirmed = true,
+                    FullName = "Viewer User",
+                    IsActive = true,
+                    CreatedAt = DateTime.UtcNow
+                };
+
+                var result = await userManager.CreateAsync(viewerUser, "Test123!");
+                if (result.Succeeded)
+                {
+                    // Same Identity "User" role as test@andy.local. The distinction
+                    // (admin on andy-policies vs not) lives in andy-rbac, not in
+                    // andy-auth's Identity roles.
+                    await userManager.AddToRoleAsync(viewerUser, "User");
+                    _logger.LogInformation(
+                        "Created viewer test user: {Email} with deterministic Id {UserId} in {Environment} environment",
+                        viewerEmail, viewerUser.Id, environment);
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "Failed to create viewer test user: {Errors}",
+                        string.Join(", ", result.Errors.Select(e => e.Description)));
+                }
+            }
+            else
+            {
+                if (existingViewer.Id != ViewerUserWellKnownId)
+                {
+                    _logger.LogWarning(
+                        "Viewer test user {Email} exists with Id {ActualId} rather than the well-known {ExpectedId}. " +
+                        "Downstream services that pre-bind roles by Id (andy-rbac et al) will not match this user. " +
+                        "To reset: delete the user via the admin UI and restart andy-auth.",
+                        viewerEmail, existingViewer.Id, ViewerUserWellKnownId);
+                }
+
+                var viewerToken = await userManager.GeneratePasswordResetTokenAsync(existingViewer);
+                var viewerResetResult = await userManager.ResetPasswordAsync(existingViewer, viewerToken, "Test123!");
+                if (viewerResetResult.Succeeded)
+                {
+                    _logger.LogInformation("Reset password for viewer test user: {Email}", viewerEmail);
+                }
+
+                if (existingViewer.AccessFailedCount > 0 || existingViewer.LockoutEnd != null)
+                {
+                    existingViewer.AccessFailedCount = 0;
+                    existingViewer.LockoutEnd = null;
+                    await userManager.UpdateAsync(existingViewer);
+                    _logger.LogInformation("Cleared lockout for viewer test user: {Email}", viewerEmail);
                 }
             }
         }

--- a/tests/Andy.Auth.Server.Tests/DbSeederTests.cs
+++ b/tests/Andy.Auth.Server.Tests/DbSeederTests.cs
@@ -265,6 +265,8 @@ public class DbSeederTests : IDisposable
 
         _mockUserManager.Setup(m => m.FindByEmailAsync("test@andy.local"))
             .ReturnsAsync((ApplicationUser?)null);
+        _mockUserManager.Setup(m => m.FindByEmailAsync("viewer@andy.local"))
+            .ReturnsAsync((ApplicationUser?)null);
 
         _mockUserManager.Setup(m => m.CreateAsync(It.IsAny<ApplicationUser>(), "Test123!"))
             .ReturnsAsync(IdentityResult.Success);
@@ -288,12 +290,58 @@ public class DbSeederTests : IDisposable
     }
 
     [Fact]
+    public async Task SeedAsync_ShouldCreateViewerTestUser_InDevelopmentEnvironment()
+    {
+        // Arrange — companion to SeedAsync_ShouldCreateTestUser_InDevelopmentEnvironment;
+        // viewer@andy.local is the no-special-permissions counterpart to test@andy.local,
+        // used by consumer E2E tests (rivoli-ai/andy-policies#109) that need an
+        // authenticated-but-unauthorized identity for 403 assertions.
+        _mockAppManager.Setup(m => m.FindByClientIdAsync(It.IsAny<string>(), default))
+            .ReturnsAsync(new object());
+
+        var configuration = CreateConfiguration("Development");
+
+        _mockUserManager.Setup(m => m.FindByEmailAsync("test@andy.local"))
+            .ReturnsAsync((ApplicationUser?)null);
+        _mockUserManager.Setup(m => m.FindByEmailAsync("viewer@andy.local"))
+            .ReturnsAsync((ApplicationUser?)null);
+
+        _mockUserManager.Setup(m => m.CreateAsync(It.IsAny<ApplicationUser>(), "Test123!"))
+            .ReturnsAsync(IdentityResult.Success);
+
+        var seeder = new DbSeeder(_serviceProvider, configuration, _mockLogger.Object, CreateHostEnvironment("Development"));
+
+        // Act
+        await seeder.SeedAsync();
+
+        // Assert
+        _mockUserManager.Verify(m => m.CreateAsync(
+            It.Is<ApplicationUser>(u =>
+                u.Id == DbSeeder.ViewerUserWellKnownId &&
+                u.Email == "viewer@andy.local" &&
+                u.UserName == "viewer@andy.local" &&
+                u.EmailConfirmed == true &&
+                u.FullName == "Viewer User" &&
+                u.IsActive == true),
+            "Test123!"),
+            Times.Once);
+    }
+
+    [Fact]
     public void TestUserWellKnownId_IsTheDocumentedConstant()
     {
         // Locks the Id contract so changing it requires a deliberate update —
         // downstream consumers (andy-rbac, andy-policies E2E) hardcode the same
         // string and would silently miss bindings if it drifted.
         Assert.Equal("00000000-0000-0000-0000-000000000001", DbSeeder.TestUserWellKnownId);
+    }
+
+    [Fact]
+    public void ViewerUserWellKnownId_IsTheDocumentedConstant()
+    {
+        // Same contract lock as TestUserWellKnownId — andy-policies E2E #109
+        // hardcodes this string for its 403 assertion.
+        Assert.Equal("00000000-0000-0000-0000-000000000002", DbSeeder.ViewerUserWellKnownId);
     }
 
     [Fact]
@@ -326,13 +374,20 @@ public class DbSeederTests : IDisposable
         var configuration = CreateConfiguration("Development");
 
         var existingUser = new ApplicationUser { Email = "test@andy.local", AccessFailedCount = 0 };
+        var existingViewer = new ApplicationUser { Email = "viewer@andy.local", AccessFailedCount = 0 };
         _mockUserManager.Setup(m => m.FindByEmailAsync("test@andy.local"))
             .ReturnsAsync(existingUser);
+        _mockUserManager.Setup(m => m.FindByEmailAsync("viewer@andy.local"))
+            .ReturnsAsync(existingViewer);
 
         // Mock password reset methods (DbSeeder resets test user password on startup)
         _mockUserManager.Setup(m => m.GeneratePasswordResetTokenAsync(existingUser))
             .ReturnsAsync("reset-token");
         _mockUserManager.Setup(m => m.ResetPasswordAsync(existingUser, "reset-token", "Test123!"))
+            .ReturnsAsync(IdentityResult.Success);
+        _mockUserManager.Setup(m => m.GeneratePasswordResetTokenAsync(existingViewer))
+            .ReturnsAsync("viewer-reset-token");
+        _mockUserManager.Setup(m => m.ResetPasswordAsync(existingViewer, "viewer-reset-token", "Test123!"))
             .ReturnsAsync(IdentityResult.Success);
 
         var seeder = new DbSeeder(_serviceProvider, configuration, _mockLogger.Object, CreateHostEnvironment("Development"));
@@ -340,10 +395,13 @@ public class DbSeederTests : IDisposable
         // Act
         await seeder.SeedAsync();
 
-        // Assert - test@andy.local should not be created since they already exist
+        // Assert - neither test user should be created since they already exist
         // Note: Admin users (sam@rivoli.ai, ty@rivoli.ai, admin@andy-auth.local) are still created
         _mockUserManager.Verify(m => m.CreateAsync(
             It.Is<ApplicationUser>(u => u.Email == "test@andy.local"),
+            It.IsAny<string>()), Times.Never);
+        _mockUserManager.Verify(m => m.CreateAsync(
+            It.Is<ApplicationUser>(u => u.Email == "viewer@andy.local"),
             It.IsAny<string>()), Times.Never);
     }
 
@@ -357,6 +415,8 @@ public class DbSeederTests : IDisposable
         var configuration = CreateConfiguration("Development");
 
         _mockUserManager.Setup(m => m.FindByEmailAsync("test@andy.local"))
+            .ReturnsAsync((ApplicationUser?)null);
+        _mockUserManager.Setup(m => m.FindByEmailAsync("viewer@andy.local"))
             .ReturnsAsync((ApplicationUser?)null);
 
         var error = new IdentityError { Description = "Password too weak" };
@@ -441,8 +501,10 @@ public class DbSeederTests : IDisposable
         // it up so the seeder doesn't NRE on a null IdentityResult.
         _mockUserManager.Setup(m => m.FindByEmailAsync("test@andy.local"))
             .ReturnsAsync((ApplicationUser?)null);
+        _mockUserManager.Setup(m => m.FindByEmailAsync("viewer@andy.local"))
+            .ReturnsAsync((ApplicationUser?)null);
         _mockUserManager.Setup(m => m.CreateAsync(
-            It.Is<ApplicationUser>(u => u.Email == "test@andy.local"),
+            It.Is<ApplicationUser>(u => u.Email == "test@andy.local" || u.Email == "viewer@andy.local"),
             It.IsAny<string>()))
             .ReturnsAsync(IdentityResult.Success);
 


### PR DESCRIPTION
## Summary

- Adds `ViewerUserWellKnownId = "00000000-0000-0000-0000-000000000002"` constant alongside the existing `TestUserWellKnownId`.
- Seeds `viewer@andy.local` / `Test123!` in non-Production environments with the same Identity "User" role as `test@andy.local`.
- Deliberately leaves the viewer subject **unbound** in downstream service manifests (only `TestUserWellKnownId` is targeted by `testUserRole` in andy-rbac's `DataSeeder`). This gives consumer E2E suites an authenticated-but-unauthorized identity for 403 assertions.

Unblocks rivoli-ai/andy-policies#109 (E2E permission check after P7).

## Test plan

- [x] Added `SeedAsync_ShouldCreateViewerTestUser_InDevelopmentEnvironment` and `ViewerUserWellKnownId_IsTheDocumentedConstant`.
- [x] Updated `SeedAsync_ShouldCreateTestUser_InDevelopmentEnvironment`, `SeedAsync_ShouldNotCreateTestUser_WhenUserAlreadyExists`, `SeedAsync_ShouldLogWarning_WhenUserCreationFails`, and `SeedAsync_AdminUser_NoPasswordEnvVar_NeverLogsPasswordValueInDevelopment` to wire viewer mocks (otherwise the new viewer code path NREs on unmocked CreateAsync).
- [x] `dotnet test` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)