### PR TITLE
fix: TestLogin honors Embedded mode, not just Development

### DIFF
--- a/src/Andy.Auth.Server/Controllers/AccountController.cs
+++ b/src/Andy.Auth.Server/Controllers/AccountController.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Andy.Auth.Server.Configuration;
 using Andy.Auth.Server.Data;
 using Andy.Auth.Server.Models;
 using Andy.Auth.Server.Services;
@@ -674,15 +675,20 @@ public class AccountController : Controller
 
     /// <summary>
     /// Test-only login endpoint that bypasses anti-forgery validation.
-    /// Only available in Development environment.
+    /// Available in every non-production deployment shape so the
+    /// Conductor desktop app's `test@andy.local` quick-sign-in path
+    /// works in Embedded mode the same way it works under `dotnet run`.
+    /// Returns 404 in Production so the endpoint cannot be probed.
     /// </summary>
     [HttpPost("~/Account/TestLogin")]
     [IgnoreAntiforgeryToken]
     public async Task<IActionResult> TestLogin([FromForm] string email, [FromForm] string password, [FromForm] string? returnUrl = null)
     {
-        // Only allow in development environment
+        // Available across every local deployment mode (Development,
+        // Docker, Embedded). The 404 keeps the endpoint invisible in
+        // Production.
         var env = HttpContext.RequestServices.GetRequiredService<IWebHostEnvironment>();
-        if (!env.IsDevelopment())
+        if (!env.IsLocalOrEmbedded())
         {
             return NotFound();
         }


### PR DESCRIPTION
## Summary

The dev-only quick-sign-in endpoint at `~/Account/TestLogin` returned `404 Not Found` for any `ASPNETCORE_ENVIRONMENT` other than `Development`. [conductor#1162](https://github.com/rivoli-ai/conductor/pull/1162) flipped Conductor's andy-auth into `ASPNETCORE_ENVIRONMENT=Embedded` so OpenIddict signing keys persist, but that flip silently disabled this endpoint — the Conductor desktop app's `test@andy.local` quick-sign-in stopped working with:

> Failed to load templates: Failed to sign in with test@andy.local via TestLogin

## Fix

Switch the gate from `IsDevelopment()` to `IsLocalOrEmbedded()` (which lives in this repo's `Configuration/HostEnvironmentExtensions.cs`):

| Env | Old | New |
|---|---|---|
| `Development` | 200 (works) | 200 (works) |
| `Docker` | 404 | 200 (new) |
| `Embedded` | 404 | 200 ✅ user-visible fix |
| `Production` | 404 | 404 (unchanged) |

Production posture preserved — the endpoint stays invisible (404) in real deployments. Same trust model as every other dev-essential branch already migrated to `IsLocalOrEmbedded()` in andy-auth (HTTPS-metadata, persisted signing keys, etc.).

Part of [conductor#1163](https://github.com/rivoli-ai/conductor/issues/1163).

## Test plan

- [x] `dotnet build src/Andy.Auth.Server` → 0 errors
- [ ] Local Conductor relaunch with rebuilt andy-auth binary → `test@andy.local` sign-in succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)