### PR TITLE
fix: TestLogin accepts Embedded environment, not only Development

### DIFF
--- a/src/Andy.Auth.Server/Controllers/AccountController.cs
+++ b/src/Andy.Auth.Server/Controllers/AccountController.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Andy.Auth.Server.Configuration;
 using Andy.Auth.Server.Data;
 using Andy.Auth.Server.Models;
 using Andy.Auth.Server.Services;
@@ -674,15 +675,23 @@ public class AccountController : Controller
 
     /// <summary>
     /// Test-only login endpoint that bypasses anti-forgery validation.
-    /// Only available in Development environment.
+    /// Available in Development AND Embedded environments. Embedded
+    /// is Conductor's standard environment string (see conductor#1162
+    /// where the switch to `Embedded` was made so OpenIddict signing
+    /// keys persist across launches). Without accepting Embedded
+    /// here, `DevAutoSignIn` in Conductor gets a 404 and the user
+    /// can't sign in to any Conductor feature.
     /// </summary>
     [HttpPost("~/Account/TestLogin")]
     [IgnoreAntiforgeryToken]
     public async Task<IActionResult> TestLogin([FromForm] string email, [FromForm] string password, [FromForm] string? returnUrl = null)
     {
-        // Only allow in development environment
+        // Allow in any non-production environment (Development, Docker,
+        // Embedded). Production deployments must use the real
+        // sign-in flow; this endpoint is for local dev + Conductor's
+        // embedded loopback only.
         var env = HttpContext.RequestServices.GetRequiredService<IWebHostEnvironment>();
-        if (!env.IsDevelopment())
+        if (!env.IsLocalOrEmbedded())
         {
             return NotFound();
         }


### PR DESCRIPTION
## Bug

Conductor sets \`ASPNETCORE_ENVIRONMENT=Embedded\` (conductor#1162 — so OpenIddict signing keys persist across launches). \`TestLogin\`'s guard checks \`env.IsDevelopment()\` which returns false for \`Embedded\` — so \`DevAutoSignIn\`'s first POST to \`/Account/TestLogin\` gets a 404 and the user can't sign in to ANY Conductor feature. Tasks, Models, Policies all blocked.

## Repro

\`\`\`
curl -X POST http://localhost:9102/Account/TestLogin?email=test@andy.local
< HTTP/1.1 404 Not Found
\`\`\`

## Fix

Use the existing \`IsLocalOrEmbedded\` helper instead of \`IsDevelopment\`. Accepts Development, Docker, AND Embedded. Production deployments use the real sign-in flow; this endpoint is for local dev + Conductor's embedded loopback only.

\`\`\`csharp
- if (!env.IsDevelopment())
+ if (!env.IsLocalOrEmbedded())
\`\`\`

Refs: conductor#1162