### PR TITLE
fix(seeder): allow admin password fallback in Embedded environment

### DIFF
--- a/src/Andy.Auth.Server/Data/DbSeeder.cs
+++ b/src/Andy.Auth.Server/Data/DbSeeder.cs
@@ -1119,14 +1119,25 @@ public class DbSeeder
                     // logged at WARN level (andy-auth#48), which leaked
                     // permanent admin access into log aggregators. Fail fast
                     // so operators set the env var explicitly.
-                    if (!_environment.IsDevelopment())
+                    //
+                    // `Embedded` (the environment Conductor uses when bundling
+                    // andy-auth inside the macOS app) is treated the same as
+                    // Development for this carveout — same policy as the OAuth
+                    // client secret seeding at line 243. Without this, the
+                    // entire seeder throws on the first admin user and
+                    // SeedTestUserAsync never reaches the test@andy.local /
+                    // viewer@andy.local creation block below, leaving the
+                    // embedded auth DB with roles + OIDC clients but zero
+                    // users. See rivoli-ai/andy-auth#100.
+                    var isEmbedded = string.Equals(_environment.EnvironmentName, "Embedded", StringComparison.OrdinalIgnoreCase);
+                    if (!_environment.IsDevelopment() && !isEmbedded)
                     {
                         throw new InvalidOperationException(
                             $"Admin user '{userInfo.Email}' has no password configured: " +
                             $"set the '{userInfo.PasswordEnvVar}' environment variable in " +
                             $"{_environment.EnvironmentName}. The dev-only generated-password " +
-                            "fallback is disabled outside the Development environment to avoid " +
-                            "leaking credentials into logs.");
+                            "fallback is disabled outside the Development/Embedded environments " +
+                            "to avoid leaking credentials into logs.");
                     }
 
                     password = userInfo.DefaultPassword;
@@ -1135,8 +1146,8 @@ public class DbSeeder
                     // exists in process memory until CreateAsync hashes it.
                     _logger.LogWarning(
                         "No password set for {Email} via {EnvVar}; using a generated password " +
-                        "for this Development run. Set {EnvVar} to choose a stable password.",
-                        userInfo.Email, userInfo.PasswordEnvVar, userInfo.PasswordEnvVar);
+                        "for this {Environment} run. Set {EnvVar} to choose a stable password.",
+                        userInfo.Email, userInfo.PasswordEnvVar, _environment.EnvironmentName, userInfo.PasswordEnvVar);
                 }
 
                 var adminUser = new ApplicationUser

--- a/tests/Andy.Auth.Server.Tests/DbSeederTests.cs
+++ b/tests/Andy.Auth.Server.Tests/DbSeederTests.cs
@@ -552,6 +552,73 @@ public class DbSeederTests : IDisposable
             m.Contains("Using generated password:") || m.Contains("generated password: "));
     }
 
+    [Fact]
+    public async Task SeedAsync_AdminUser_NoPasswordEnvVar_DoesNotThrowInEmbedded()
+    {
+        // Regression for rivoli-ai/andy-auth#100. Conductor runs andy-auth with
+        // ASPNETCORE_ENVIRONMENT=Embedded. Before this fix, missing
+        // ADMIN_PASSWORD_* env vars made the seeder throw on the FIRST admin
+        // user (sam@rivoli.ai) — aborting before SeedTestUserAsync ever reached
+        // its test@andy.local / viewer@andy.local creation block. The embedded
+        // auth DB then booted with roles + OIDC clients but zero users, and
+        // every Conductor panel surfaced "Failed to sign in with
+        // test@andy.local via TestLogin" forever. Treat Embedded like
+        // Development for this carveout — symmetric with the OAuth client
+        // secret seeding at DbSeeder.cs:243.
+        _mockUserManager.Setup(m => m.FindByEmailAsync("test@andy.local"))
+            .ReturnsAsync((ApplicationUser?)null);
+        _mockUserManager.Setup(m => m.FindByEmailAsync("viewer@andy.local"))
+            .ReturnsAsync((ApplicationUser?)null);
+        _mockUserManager.Setup(m => m.CreateAsync(
+            It.Is<ApplicationUser>(u => u.Email == "test@andy.local" || u.Email == "viewer@andy.local"),
+            It.IsAny<string>()))
+            .ReturnsAsync(IdentityResult.Success);
+
+        Environment.SetEnvironmentVariable("ADMIN_PASSWORD_SAM", null);
+        Environment.SetEnvironmentVariable("ADMIN_PASSWORD_TY", null);
+        Environment.SetEnvironmentVariable("ADMIN_PASSWORD_DEFAULT", null);
+
+        var loggedMessages = new List<string>();
+        var capturingLogger = new Mock<ILogger<DbSeeder>>();
+        capturingLogger.Setup(x => x.Log(
+            It.IsAny<LogLevel>(),
+            It.IsAny<EventId>(),
+            It.IsAny<It.IsAnyType>(),
+            It.IsAny<Exception?>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+            .Callback(new InvocationAction(invocation =>
+            {
+                var state = invocation.Arguments[2];
+                var formatter = invocation.Arguments[4];
+                var message = formatter.GetType().GetMethod("Invoke")!
+                    .Invoke(formatter, new[] { state, invocation.Arguments[3] }) as string;
+                if (message is not null) loggedMessages.Add(message);
+            }));
+
+        _mockAppManager.Setup(m => m.FindByClientIdAsync(It.IsAny<string>(), default))
+            .ReturnsAsync(new object());
+
+        var configuration = CreateConfiguration("Embedded");
+        var seeder = new DbSeeder(
+            _serviceProvider, configuration, capturingLogger.Object, CreateHostEnvironment("Embedded"));
+
+        // Must NOT throw — the throw was the symptom that aborted user seeding.
+        await seeder.SeedAsync();
+
+        // Test user creation must have been reached and invoked.
+        _mockUserManager.Verify(m => m.CreateAsync(
+            It.Is<ApplicationUser>(u => u.Email == "test@andy.local"),
+            It.IsAny<string>()), Times.Once);
+
+        // The dev-fallback warning must name the env var and the Embedded
+        // environment — operators need a breadcrumb to set a stable password
+        // without having to grep the source.
+        Assert.Contains(loggedMessages, m => m.Contains("ADMIN_PASSWORD_SAM"));
+        Assert.Contains(loggedMessages, m => m.Contains("Embedded"));
+        Assert.DoesNotContain(loggedMessages, m =>
+            m.Contains("Using generated password:") || m.Contains("generated password: "));
+    }
+
     #endregion
 
     #region Issue #47 — Hardcoded fallback client secret regression


### PR DESCRIPTION
## Summary

`SeedTestUserAsync` was missing the `Embedded` carveout that #99 added for confidential-client secrets. The admin-user password guard at `DbSeeder.cs:1122` threw on the first iteration (`sam@rivoli.ai`) when no `ADMIN_PASSWORD_*` env var was set, aborting the seeder before it reached test-user creation. The embedded auth DB then booted with roles + 28 OIDC clients but **zero users**, and every Conductor panel showed `Failed to sign in with test@andy.local via TestLogin` forever.

Fixes #100.

## Changes

- `Data/DbSeeder.cs`: extend the missing-env-var guard at line 1122 with `&& !isEmbedded`, mirroring the existing pattern at line 243. Update the throw message to read "outside the Development/Embedded environments" and thread the actual environment name through the dev-fallback warning so operators see "Embedded" in logs.
- `tests/Andy.Auth.Server.Tests/DbSeederTests.cs`: new regression test `SeedAsync_AdminUser_NoPasswordEnvVar_DoesNotThrowInEmbedded`. Asserts no throw, that `UserManager.CreateAsync` is invoked for `test@andy.local`, that the warning log names both `ADMIN_PASSWORD_SAM` and `Embedded`, and that the password value never appears in any log message (the #48 no-leak guarantee still holds).

## Production safety

The existing `SeedAsync_AdminUser_NoPasswordEnvVar_ThrowsInProduction` test still passes alongside the new test — Production env still aborts on missing env vars (the andy-auth#48 invariant) and only `Development` + `Embedded` get the generated-password fallback.

## Test plan

- [x] `dotnet test tests/Andy.Auth.Server.Tests --filter "FullyQualifiedName~DbSeederTests"` — 16/19 passed (3 pre-existing skips unrelated)
- [x] `dotnet build src/Andy.Auth.Server` — clean (0 errors, pre-existing nullable-ref warnings only)
- [x] Manual e2e: edit-build-run andy-auth under Conductor's bundled-services orchestrator with `ASPNETCORE_ENVIRONMENT=Embedded` and no `ADMIN_PASSWORD_*` env vars. Without this fix → 0 users in `AspNetUsers`, every panel surfaces the TestLogin failure. With this fix → 5 users seeded (3 admins + `test@andy.local` + `viewer@andy.local`), TestLogin returns 200, all Conductor panels load data.

## Follow-up

There is a temporary workaround on the Conductor side (`AuthServiceConfig.swift` injects placeholder `ADMIN_PASSWORD_*` env vars in the `Embedded` env). Once this PR merges and andy-auth's binary is re-vendored into Conductor's bundled-services pipeline, that workaround can be reverted. The workaround block is commented with `rivoli-ai/andy-auth#100` so it surfaces in greps when this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)