### PR TITLE
feat(idp-1): Andy.Auth.M2MClient — delegated (OBO) token provider

### DIFF
--- a/src/Andy.Auth.M2MClient/IDelegatedTokenProvider.cs
+++ b/src/Andy.Auth.M2MClient/IDelegatedTokenProvider.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Auth.M2MClient;
+
+/// <summary>
+/// Provides cached <em>on-behalf-of</em> access tokens via the RFC 8693
+/// OAuth 2.0 Token Exchange grant. Where
+/// <see cref="IServiceTokenProvider"/> mints a token for the service
+/// itself, this interface mints a token where:
+///
+/// <list type="bullet">
+///   <item><description><c>sub</c> is the original end user (taken from the supplied <c>subjectToken</c>),</description></item>
+///   <item><description><c>act</c> records the calling service as the actor,</description></item>
+///   <item><description><c>aud</c> names the requested downstream service.</description></item>
+/// </list>
+///
+/// Use this on any service-to-service call that originates from a user
+/// request — without it, the downstream RBAC check sees only the
+/// service principal (and falls back to <c>anonymous</c> when the
+/// service identity isn't an RBAC subject) instead of the actual user.
+/// That failure mode is what rivoli-ai/andy-containers#305 exposed.
+///
+/// Drives Epic IDP (rivoli-ai/conductor#1246).
+/// </summary>
+public interface IDelegatedTokenProvider
+{
+    /// <summary>
+    /// Returns a valid bearer token issued via token exchange.
+    ///
+    /// The supplied <paramref name="subjectToken"/> must be an access
+    /// token issued by the same andy-auth this provider talks to (the
+    /// server-side validator rejects tokens from other issuers).
+    /// <paramref name="audience"/> names the downstream service the
+    /// returned token will be presented to (e.g.
+    /// <c>urn:andy-models-api</c>); the same value is used as the OAuth
+    /// 2.0 <c>resource</c> parameter on the token request.
+    ///
+    /// Implementations cache by (<paramref name="subjectToken"/>,
+    /// <paramref name="audience"/>) and refresh ahead of expiry.
+    /// Concurrent callers for the same key coalesce behind a single
+    /// in-flight request.
+    /// </summary>
+    /// <exception cref="ServiceTokenException">
+    /// Thrown when the token endpoint is unreachable, rejects the
+    /// request (e.g. policy denial → <c>unauthorized_client</c>,
+    /// invalid subject token → <c>invalid_grant</c>), or returns an
+    /// empty <c>access_token</c>. The message carries an
+    /// <c>[M2M-*]</c> prefix the caller can grep / surface.
+    /// </exception>
+    Task<string> GetTokenOnBehalfOfAsync(
+        string subjectToken,
+        string audience,
+        CancellationToken ct = default);
+}

--- a/src/Andy.Auth.M2MClient/ServiceCollectionExtensions.cs
+++ b/src/Andy.Auth.M2MClient/ServiceCollectionExtensions.cs
@@ -39,6 +39,13 @@ public static class ServiceCollectionExtensions
             sp.GetRequiredService<ClientCredentialsTokenProvider>());
         services.TryAddSingleton<IRefreshableServiceTokenProvider>(sp =>
             sp.GetRequiredService<ClientCredentialsTokenProvider>());
+        // RFC 8693 OBO provider — sibling of ClientCredentialsTokenProvider.
+        // Shares the same named HttpClient ("AndyAuthM2M"); per-(subject,
+        // audience) cache keeps the fast path lock-free.
+        // Drives Epic IDP (rivoli-ai/conductor#1246).
+        services.TryAddSingleton<TokenExchangeDelegatedTokenProvider>();
+        services.TryAddSingleton<IDelegatedTokenProvider>(sp =>
+            sp.GetRequiredService<TokenExchangeDelegatedTokenProvider>());
         services.TryAddTransient<ServiceBearerHandler>();
         services.AddHttpClient(ClientCredentialsTokenProvider.HttpClientName);
 

--- a/src/Andy.Auth.M2MClient/TokenExchangeDelegatedTokenProvider.cs
+++ b/src/Andy.Auth.M2MClient/TokenExchangeDelegatedTokenProvider.cs
@@ -1,0 +1,276 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Concurrent;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Andy.Auth.M2MClient;
+
+/// <summary>
+/// RFC 8693 OAuth 2.0 Token Exchange implementation of
+/// <see cref="IDelegatedTokenProvider"/>.
+///
+/// Posts <c>grant_type=urn:ietf:params:oauth:grant-type:token-exchange</c>
+/// to the andy-auth token endpoint, presenting the caller's own
+/// <c>client_credentials</c> (from <see cref="AndyAuthM2MOptions"/>)
+/// together with the supplied <c>subject_token</c> and target
+/// <c>resource</c> (audience). The returned access token has
+/// <c>sub</c>=user, <c>act</c>=service, <c>aud</c>=audience.
+///
+/// Caching is per (<c>subject_token</c>, <c>audience</c>) — keyed by a
+/// SHA-256 hash of the subject token so the raw user JWT never lives
+/// in a cache key. Concurrent callers for the same key coalesce behind
+/// a single in-flight task, same pattern as
+/// <see cref="ClientCredentialsTokenProvider"/>.
+///
+/// Drives Epic IDP (rivoli-ai/conductor#1246).
+/// </summary>
+public sealed class TokenExchangeDelegatedTokenProvider : IDelegatedTokenProvider, IDisposable
+{
+    /// <summary>
+    /// RFC 8693 §2.1 grant-type URN.
+    /// </summary>
+    public const string GrantTypeUrn = "urn:ietf:params:oauth:grant-type:token-exchange";
+
+    /// <summary>
+    /// RFC 8693 §3 token-type URN identifying an OAuth 2.0 access
+    /// token. The only <c>subject_token_type</c> we send.
+    /// </summary>
+    public const string AccessTokenTypeUrn = "urn:ietf:params:oauth:token-type:access_token";
+
+    private static readonly TimeSpan RefreshSkew = TimeSpan.FromSeconds(60);
+
+    private readonly IHttpClientFactory _factory;
+    private readonly AndyAuthM2MOptions _options;
+    private readonly TimeProvider _time;
+    private readonly ILogger<TokenExchangeDelegatedTokenProvider> _logger;
+
+    /// <summary>
+    /// Per-(subjectTokenHash, audience) entries. Each holds a
+    /// semaphore for in-flight coalescing plus the most-recent cached
+    /// token + expiry. The <see cref="ConcurrentDictionary{TKey, TValue}"/>
+    /// keeps the fast path lock-free.
+    /// </summary>
+    private readonly ConcurrentDictionary<CacheKey, CacheEntry> _entries = new();
+
+    public TokenExchangeDelegatedTokenProvider(
+        IHttpClientFactory factory,
+        IOptions<AndyAuthM2MOptions> options,
+        TimeProvider time,
+        ILogger<TokenExchangeDelegatedTokenProvider> logger)
+    {
+        _factory = factory;
+        _options = options.Value;
+        _time = time;
+        _logger = logger;
+    }
+
+    public async Task<string> GetTokenOnBehalfOfAsync(
+        string subjectToken,
+        string audience,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(subjectToken))
+        {
+            throw new ServiceTokenException(
+                "[M2M-OBO-NOSUBJECT] subject_token must not be empty.");
+        }
+        if (string.IsNullOrWhiteSpace(audience))
+        {
+            throw new ServiceTokenException(
+                "[M2M-OBO-NOAUDIENCE] audience must not be empty.");
+        }
+
+        var key = new CacheKey(HashSubject(subjectToken), audience);
+        var entry = _entries.GetOrAdd(key, _ => new CacheEntry());
+
+        var now = _time.GetUtcNow();
+        if (entry.CachedToken is not null && now < entry.CachedUntil - RefreshSkew)
+        {
+            return entry.CachedToken;
+        }
+
+        return await RefreshCoalescedAsync(entry, subjectToken, audience, ct).ConfigureAwait(false);
+    }
+
+    private async Task<string> RefreshCoalescedAsync(
+        CacheEntry entry,
+        string subjectToken,
+        string audience,
+        CancellationToken ct)
+    {
+        await entry.Gate.WaitAsync(ct).ConfigureAwait(false);
+        Task<string> task;
+        try
+        {
+            var now = _time.GetUtcNow();
+            if (entry.CachedToken is not null && now < entry.CachedUntil - RefreshSkew)
+            {
+                return entry.CachedToken;
+            }
+            task = entry.Inflight ??= FetchAsync(entry, subjectToken, audience, ct);
+        }
+        finally
+        {
+            entry.Gate.Release();
+        }
+
+        try
+        {
+            return await task.ConfigureAwait(false);
+        }
+        finally
+        {
+            await entry.Gate.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+            try
+            {
+                if (ReferenceEquals(entry.Inflight, task))
+                {
+                    entry.Inflight = null;
+                }
+            }
+            finally
+            {
+                entry.Gate.Release();
+            }
+        }
+    }
+
+    private async Task<string> FetchAsync(
+        CacheEntry entry,
+        string subjectToken,
+        string audience,
+        CancellationToken ct)
+    {
+        var endpoint = _options.ResolveTokenEndpoint();
+        var clientId = _options.ClientId;
+        if (string.IsNullOrWhiteSpace(clientId))
+        {
+            throw new ServiceTokenException(
+                "[M2M-OBO-NOCLIENTID] AndyAuth.ClientId is not configured.");
+        }
+        var secret = ResolveSecret(clientId);
+
+        var form = new List<KeyValuePair<string, string>>
+        {
+            new("grant_type", GrantTypeUrn),
+            new("client_id", clientId),
+            new("client_secret", secret),
+            new("subject_token", subjectToken),
+            new("subject_token_type", AccessTokenTypeUrn),
+            new("resource", audience),
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new FormUrlEncodedContent(form),
+        };
+
+        var client = _factory.CreateClient(ClientCredentialsTokenProvider.HttpClientName);
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.SendAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new ServiceTokenException(
+                $"[M2M-OBO-UNREACHABLE] andy-auth token endpoint at {endpoint} is unreachable: {ex.Message}", ex);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                throw new ServiceTokenException(
+                    $"[M2M-OBO-REJECTED] andy-auth token endpoint returned {(int)response.StatusCode} {response.ReasonPhrase} for token exchange (audience={audience}): {body}");
+            }
+
+            var payload = await response.Content
+                .ReadFromJsonAsync<TokenResponse>(cancellationToken: ct)
+                .ConfigureAwait(false);
+            if (payload is null || string.IsNullOrEmpty(payload.AccessToken))
+            {
+                throw new ServiceTokenException(
+                    "[M2M-OBO-EMPTY] andy-auth returned an empty access_token for token exchange.");
+            }
+
+            var lifetime = payload.ExpiresIn > 0 ? payload.ExpiresIn : 300;
+            var expiresAt = _time.GetUtcNow().AddSeconds(lifetime);
+
+            await entry.Gate.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+            try
+            {
+                entry.CachedToken = payload.AccessToken;
+                entry.CachedUntil = expiresAt;
+            }
+            finally
+            {
+                entry.Gate.Release();
+            }
+
+            _logger.LogDebug(
+                "Acquired delegated token for client {ClientId} -> {Audience}; expires in {Lifetime}s",
+                clientId, audience, lifetime);
+            return payload.AccessToken;
+        }
+    }
+
+    private string ResolveSecret(string clientId)
+    {
+        var envVar = _options.ClientSecretEnvVar;
+        if (string.IsNullOrWhiteSpace(envVar))
+        {
+            throw new ServiceTokenException(
+                "[M2M-OBO-NOSECRETENV] AndyAuth.ClientSecretEnvVar is not configured; cannot resolve client_secret.");
+        }
+        var secret = Environment.GetEnvironmentVariable(envVar);
+        if (!string.IsNullOrEmpty(secret))
+        {
+            return secret;
+        }
+        var fallback = $"{clientId}-secret-change-in-production";
+        _logger.LogWarning(
+            "Environment variable {EnvVar} is not set; falling back to dev secret for client {ClientId}. " +
+            "This is fine for dev/embedded but MUST be overridden in production.",
+            envVar, clientId);
+        return fallback;
+    }
+
+    private static string HashSubject(string subjectToken)
+    {
+        var bytes = Encoding.UTF8.GetBytes(subjectToken);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash);
+    }
+
+    public void Dispose()
+    {
+        foreach (var entry in _entries.Values)
+        {
+            entry.Gate.Dispose();
+        }
+    }
+
+    private readonly record struct CacheKey(string SubjectTokenHash, string Audience);
+
+    private sealed class CacheEntry
+    {
+        public SemaphoreSlim Gate { get; } = new(1, 1);
+        public string? CachedToken;
+        public DateTimeOffset CachedUntil;
+        public Task<string>? Inflight;
+    }
+
+    private sealed record TokenResponse(
+        [property: JsonPropertyName("access_token")] string AccessToken,
+        [property: JsonPropertyName("token_type")] string? TokenType,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn,
+        [property: JsonPropertyName("issued_token_type")] string? IssuedTokenType);
+}

--- a/tests/Andy.Auth.M2MClient.Tests/TokenExchangeDelegatedTokenProviderTests.cs
+++ b/tests/Andy.Auth.M2MClient.Tests/TokenExchangeDelegatedTokenProviderTests.cs
@@ -1,0 +1,308 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Andy.Auth.M2MClient.Tests;
+
+/// <summary>
+/// Tests for the RFC 8693 OBO token provider. Mirrors the patterns in
+/// <c>ClientCredentialsTokenProviderTests</c> — same stub HTTP handler,
+/// fake time provider, single-client factory. Drives Epic IDP
+/// (rivoli-ai/conductor#1246).
+/// </summary>
+public sealed class TokenExchangeDelegatedTokenProviderTests
+{
+    private const string EnvVar = "ANDY_AUTH_M2M_TESTS_SECRET";
+    private const string ClientId = "andy-containers-api";
+    private const string TokenEndpoint = "http://andy-auth.test/connect/token";
+    private const string SubjectToken = "header.payload.signature";
+    private const string Audience = "urn:andy-models-api";
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_PostsExpectedFormFields()
+    {
+        string? observed = null;
+        var handler = new StubHandler(async (req, ct) =>
+        {
+            observed = await req.Content!.ReadAsStringAsync(ct);
+            return TokenResponse("delegated-jwt", expiresIn: 900);
+        });
+        using var provider = NewProvider(handler, new FakeTimeProvider());
+
+        var token = await provider.GetTokenOnBehalfOfAsync(SubjectToken, Audience);
+
+        Assert.Equal("delegated-jwt", token);
+        Assert.NotNull(observed);
+        Assert.Contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange", observed);
+        Assert.Contains($"client_id={ClientId}", observed);
+        Assert.Contains("subject_token=header.payload.signature", observed);
+        Assert.Contains("subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token", observed);
+        Assert.Contains("resource=urn%3Aandy-models-api", observed);
+    }
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_CachesPerSubjectAudiencePair()
+    {
+        var calls = 0;
+        var handler = new StubHandler((req, _) =>
+        {
+            calls++;
+            return Task.FromResult(TokenResponse($"token-{calls}", expiresIn: 3600));
+        });
+        using var provider = NewProvider(handler, new FakeTimeProvider());
+
+        var first = await provider.GetTokenOnBehalfOfAsync(SubjectToken, Audience);
+        var second = await provider.GetTokenOnBehalfOfAsync(SubjectToken, Audience);
+
+        Assert.Equal("token-1", first);
+        Assert.Equal("token-1", second);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_SeparateCacheForDifferentAudience()
+    {
+        var calls = 0;
+        var handler = new StubHandler((req, _) =>
+        {
+            calls++;
+            return Task.FromResult(TokenResponse($"token-{calls}", expiresIn: 3600));
+        });
+        using var provider = NewProvider(handler, new FakeTimeProvider());
+
+        var modelsToken = await provider.GetTokenOnBehalfOfAsync(SubjectToken, "urn:andy-models-api");
+        var settingsToken = await provider.GetTokenOnBehalfOfAsync(SubjectToken, "urn:andy-settings-api");
+        var modelsAgain = await provider.GetTokenOnBehalfOfAsync(SubjectToken, "urn:andy-models-api");
+
+        Assert.Equal("token-1", modelsToken);
+        Assert.Equal("token-2", settingsToken);
+        Assert.Equal("token-1", modelsAgain);
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_SeparateCacheForDifferentSubject()
+    {
+        var calls = 0;
+        var handler = new StubHandler((req, _) =>
+        {
+            calls++;
+            return Task.FromResult(TokenResponse($"token-{calls}", expiresIn: 3600));
+        });
+        using var provider = NewProvider(handler, new FakeTimeProvider());
+
+        var userA = await provider.GetTokenOnBehalfOfAsync("user-a.jwt.sig", Audience);
+        var userB = await provider.GetTokenOnBehalfOfAsync("user-b.jwt.sig", Audience);
+
+        Assert.Equal("token-1", userA);
+        Assert.Equal("token-2", userB);
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_RefreshesNearExpiry()
+    {
+        var calls = 0;
+        var handler = new StubHandler((req, _) =>
+        {
+            calls++;
+            return Task.FromResult(TokenResponse(calls == 1 ? "first" : "second", expiresIn: 120));
+        });
+        var time = new FakeTimeProvider();
+        using var provider = NewProvider(handler, time);
+
+        var t1 = await provider.GetTokenOnBehalfOfAsync(SubjectToken, Audience);
+        time.Advance(TimeSpan.FromSeconds(59));
+        var t2 = await provider.GetTokenOnBehalfOfAsync(SubjectToken, Audience);
+        time.Advance(TimeSpan.FromSeconds(2));
+        var t3 = await provider.GetTokenOnBehalfOfAsync(SubjectToken, Audience);
+
+        Assert.Equal("first", t1);
+        Assert.Equal("first", t2);
+        Assert.Equal("second", t3);
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_CoalescesConcurrentFirstCalls()
+    {
+        var calls = 0;
+        var release = new TaskCompletionSource();
+        var handler = new StubHandler(async (_, _) =>
+        {
+            Interlocked.Increment(ref calls);
+            await release.Task.ConfigureAwait(false);
+            return TokenResponse("shared", expiresIn: 3600);
+        });
+        using var provider = NewProvider(handler, new FakeTimeProvider());
+
+        var t1 = provider.GetTokenOnBehalfOfAsync(SubjectToken, Audience);
+        var t2 = provider.GetTokenOnBehalfOfAsync(SubjectToken, Audience);
+        var t3 = provider.GetTokenOnBehalfOfAsync(SubjectToken, Audience);
+        release.SetResult();
+        var results = await Task.WhenAll(t1, t2, t3);
+
+        Assert.All(results, r => Assert.Equal("shared", r));
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_ThrowsServiceTokenException_OnRejection()
+    {
+        var handler = new StubHandler((_, _) => Task.FromResult(
+            new HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Content = new StringContent(
+                    "{\"error\":\"unauthorized_client\",\"error_description\":\"the actor is not permitted to exchange tokens for this audience.\"}",
+                    Encoding.UTF8, "application/json"),
+            }));
+        using var provider = NewProvider(handler, new FakeTimeProvider());
+
+        var ex = await Assert.ThrowsAsync<ServiceTokenException>(() =>
+            provider.GetTokenOnBehalfOfAsync(SubjectToken, Audience));
+        Assert.Contains("[M2M-OBO-REJECTED]", ex.Message);
+        Assert.Contains("403", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_ThrowsServiceTokenException_OnUnreachable()
+    {
+        var handler = new StubHandler((_, _) =>
+            throw new HttpRequestException("Connection refused"));
+        using var provider = NewProvider(handler, new FakeTimeProvider());
+
+        var ex = await Assert.ThrowsAsync<ServiceTokenException>(() =>
+            provider.GetTokenOnBehalfOfAsync(SubjectToken, Audience));
+        Assert.Contains("[M2M-OBO-UNREACHABLE]", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_ThrowsServiceTokenException_OnEmptyAccessToken()
+    {
+        var handler = new StubHandler((_, _) => Task.FromResult(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "{\"token_type\":\"Bearer\",\"expires_in\":900}",
+                    Encoding.UTF8, "application/json"),
+            }));
+        using var provider = NewProvider(handler, new FakeTimeProvider());
+
+        var ex = await Assert.ThrowsAsync<ServiceTokenException>(() =>
+            provider.GetTokenOnBehalfOfAsync(SubjectToken, Audience));
+        Assert.Contains("[M2M-OBO-EMPTY]", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_RejectsEmptySubjectToken()
+    {
+        var handler = new StubHandler((_, _) => Task.FromResult(TokenResponse("x", 60)));
+        using var provider = NewProvider(handler, new FakeTimeProvider());
+
+        var ex = await Assert.ThrowsAsync<ServiceTokenException>(() =>
+            provider.GetTokenOnBehalfOfAsync("", Audience));
+        Assert.Contains("[M2M-OBO-NOSUBJECT]", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_RejectsEmptyAudience()
+    {
+        var handler = new StubHandler((_, _) => Task.FromResult(TokenResponse("x", 60)));
+        using var provider = NewProvider(handler, new FakeTimeProvider());
+
+        var ex = await Assert.ThrowsAsync<ServiceTokenException>(() =>
+            provider.GetTokenOnBehalfOfAsync(SubjectToken, ""));
+        Assert.Contains("[M2M-OBO-NOAUDIENCE]", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_RefetchesAfterFailure()
+    {
+        // A previous rejection should NOT leave a stale cache entry —
+        // the next call must hit the wire again.
+        var calls = 0;
+        var handler = new StubHandler((_, _) =>
+        {
+            calls++;
+            if (calls == 1)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Forbidden)
+                {
+                    Content = new StringContent("{\"error\":\"unauthorized_client\"}",
+                        Encoding.UTF8, "application/json"),
+                });
+            }
+            return Task.FromResult(TokenResponse("recovered", expiresIn: 3600));
+        });
+        using var provider = NewProvider(handler, new FakeTimeProvider());
+
+        await Assert.ThrowsAsync<ServiceTokenException>(() =>
+            provider.GetTokenOnBehalfOfAsync(SubjectToken, Audience));
+        var second = await provider.GetTokenOnBehalfOfAsync(SubjectToken, Audience);
+
+        Assert.Equal("recovered", second);
+        Assert.Equal(2, calls);
+    }
+
+    // ------- helpers (shape-identical to ClientCredentialsTokenProviderTests) -------
+
+    private static TokenExchangeDelegatedTokenProvider NewProvider(
+        HttpMessageHandler handler, TimeProvider time)
+    {
+        var http = new HttpClient(handler);
+        var factory = new SingleClientFactory(http);
+        var options = Options.Create(new AndyAuthM2MOptions
+        {
+            TokenEndpoint = TokenEndpoint,
+            ClientId = ClientId,
+            ClientSecretEnvVar = EnvVar,
+        });
+        return new TokenExchangeDelegatedTokenProvider(
+            factory, options, time, NullLogger<TokenExchangeDelegatedTokenProvider>.Instance);
+    }
+
+    private static HttpResponseMessage TokenResponse(string accessToken, int expiresIn)
+    {
+        // Note: only the first segment is interpolated, so the leading
+        // `{{` collapses to `{`. The trailing literal `}` must be a
+        // single brace because the second string is not interpolated.
+        var json =
+            $"{{\"access_token\":\"{accessToken}\",\"token_type\":\"Bearer\",\"expires_in\":{expiresIn}," +
+            "\"issued_token_type\":\"urn:ietf:params:oauth:token-type:access_token\"}";
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+    }
+
+    private sealed class SingleClientFactory : IHttpClientFactory
+    {
+        private readonly HttpClient _client;
+        public SingleClientFactory(HttpClient client) { _client = client; }
+        public HttpClient CreateClient(string name) => _client;
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _respond;
+        public StubHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> respond)
+        {
+            _respond = respond;
+        }
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => _respond(request, cancellationToken);
+    }
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now = new(2026, 5, 13, 12, 0, 0, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+    }
+}


### PR DESCRIPTION
## Summary

Client-side counterpart to the RFC 8693 token-exchange grant that landed in #102. Consumer services now get a single primitive for cross-service identity propagation:

\`\`\`csharp
Task<string> GetTokenOnBehalfOfAsync(string subjectToken,
                                     string audience,
                                     CancellationToken ct = default);
\`\`\`

Where \`IServiceTokenProvider.GetTokenAsync\` mints a token for the **service itself**, \`IDelegatedTokenProvider\` mints one whose \`sub\` is the **end user**, \`act\` records the calling service, and \`aud\` names the downstream service.

This is the primitive every actively-broken call site surfaced by the Epic IDP audit needs in order to stop arriving at RBAC as \`anonymous\`. Once IDP.2 (server-side subject extraction) lands, the consumer migrations in IDP.3/4/5 are largely a search-and-replace from \`GetTokenAsync\` / \`GetAccessTokenAsync\` to \`GetTokenOnBehalfOfAsync\`.

## What's in this PR

- **\`IDelegatedTokenProvider\`** — one method, doc-commented surface contract.
- **\`TokenExchangeDelegatedTokenProvider\`** — RFC 8693 implementation. Shares the existing \`"AndyAuthM2M"\` named \`HttpClient\` with the M2M provider; same env-var-driven secret resolution + dev-fallback warning.
- **Cache** — per (\`subjectTokenHash\`, \`audience\`). Lock-free fast path via \`ConcurrentDictionary\`; per-entry semaphore for in-flight coalescing of concurrent identical requests. Subject token is hashed (SHA-256) so the raw user JWT never lives in a cache key.
- **Refresh** — same 60s skew before \`expires_in\` as the M2M provider.
- **DI** — \`AddAndyAuthM2M\` registers \`IDelegatedTokenProvider\` as a singleton. Idempotent; no breaking change.

## Test plan

12 new tests, all passing:

- Form-field shape (every RFC 8693 parameter as expected — \`grant_type\`, \`subject_token\`, \`subject_token_type\`, \`resource\`, \`client_id\`, \`client_secret\`)
- Cache by (subject, audience); separate caches per audience; separate caches per subject
- Refresh on expiry skew (with \`FakeTimeProvider\` advancing through the 60s boundary)
- Concurrent coalescing (3 callers, 1 wire call)
- All error paths surface as \`ServiceTokenException\` with greppable codes:
  - \`[M2M-OBO-REJECTED]\` on 4xx/5xx response
  - \`[M2M-OBO-UNREACHABLE]\` on \`HttpRequestException\`
  - \`[M2M-OBO-EMPTY]\` on response with no \`access_token\`
  - \`[M2M-OBO-NOSUBJECT]\` / \`[M2M-OBO-NOAUDIENCE]\` on argument validation
- Refetch-after-failure (no stale cache after a 4xx)

Full \`Andy.Auth.M2MClient.Tests\` suite: 40/40 passing.

## Out of scope

- **\`GetBearerOnBehalfOfStoredSubjectAsync\`** (the background-path variant — for paths like container destroy that don't have a live user JWT). Needs new server-side support (a way for a service to authenticate as itself but assert a stored user \`sub\`) that doesn't exist yet. Will be designed alongside IDP.3 when the container-destroy revoke path is wired up.
- **Consumer migrations** — that's IDP.3 (\`andy-containers\`), IDP.4 (\`andy-agents\`), IDP.5 (\`andy-issues\`).

## Related

- Epic IDP: rivoli-ai/conductor#1246
- Server-side: rivoli-ai/andy-auth#102 (merged)
- Catalyst bug: rivoli-ai/andy-containers#305

🤖 Generated with [Claude Code](https://claude.com/claude-code)