### PR TITLE
docs: refresh stale markdown content

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd src/Andy.Auth.Server
 dotnet run
 ```
 
-Server runs at: **https://localhost:7088**
+Server runs at: **https://localhost:5001**
 
 **Test credentials:**
 - Email: `test@andy.local`
@@ -174,7 +174,7 @@ Run all examples tests:
 | [SECURITY.md](./docs/SECURITY.md) | Security features |
 | [ADMIN.md](./docs/ADMIN.md) | Admin UI documentation |
 | [DEPLOYMENT.md](./docs/DEPLOYMENT.md) | Production deployment |
-| [TESTING.md](./docs/TESTING.md) | Testing guide |
+| [testing.md](./docs/testing.md) | Testing guide |
 | [LIBRARY.md](./docs/LIBRARY.md) | Client library documentation |
 | [ASSISTANT-INTEGRATION.md](./docs/ASSISTANT-INTEGRATION.md) | AI assistant setup |
 
@@ -190,11 +190,9 @@ cd tests/oauth-python
 ANDY_AUTH_TEST_PASSWORD="Test123!" python3 run_all_tests.py --env uat
 ```
 
-**Current Status:**
-- .NET unit tests: 54/54 passed (100%)
-- Python OAuth tests: 42/42 passed (100%)
+**Current Status:** See [docs/testing.md](./docs/testing.md) for the latest test counts and pass rates.
 
-See [docs/TESTING.md](./docs/TESTING.md) for testing guide.
+See [docs/testing.md](./docs/testing.md) for testing guide.
 
 ## Contributing
 

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -6,7 +6,7 @@ Admin dashboard documentation for managing users, OAuth clients, and audit logs.
 
 The admin dashboard provides a web-based interface for managing Andy Auth Server. Access it at:
 
-**Development:** https://localhost:7088/Admin
+**Development:** https://localhost:5001/Admin
 **Production:** https://auth.rivoli.ai/Admin
 
 ## Features

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -265,7 +265,7 @@ Layer 6: Application
 │  localhost                           │
 ├─────────────────────────────────────┤
 │  Andy.Auth.Server                    │
-│  https://localhost:7088              │
+│  https://localhost:5001              │
 │  ├─ Ephemeral signing keys           │
 │  └─ Local PostgreSQL                 │
 │     (docker-compose)                 │

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -309,7 +309,7 @@ Change providers by updating configuration:
 {
   "AndyAuth": {
     "Provider": "AndyAuth",
-    "Authority": "https://localhost:7088"
+    "Authority": "https://localhost:5001"
   }
 }
 ```
@@ -546,7 +546,7 @@ builder.Services.AddAndyAuth(options =>
 ```json
 {
   "AndyAuth": {
-    "Authority": "https://localhost:7088",
+    "Authority": "https://localhost:5001",
     "RequireHttpsMetadata": false
   }
 }
@@ -716,7 +716,7 @@ var app = builder.Build();
 
 ### Complete Andy Docs Integration
 
-See `examples/Andy DocsIntegration/` for a working example showing:
+See `examples/AndyDocsIntegration/` for a working example showing:
 - Andy.Auth library setup
 - ICurrentUserService usage
 - Role-based authorization

--- a/examples/AndyDocsIntegration/README.md
+++ b/examples/AndyDocsIntegration/README.md
@@ -33,7 +33,7 @@ dotnet add package Andy.Auth
 {
   "AndyAuth": {
     "Provider": "AndyAuth",
-    "Authority": "https://localhost:7088",
+    "Authority": "https://localhost:5001",
     "Audience": "andy-docs-api",
     "RequireHttpsMetadata": false
   }
@@ -65,14 +65,14 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
-        options.Authority = "https://localhost:7088";
+        options.Authority = "https://localhost:5001";
         options.Audience = "andy-docs-api";
         options.RequireHttpsMetadata = false;
 
         options.TokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuer = true,
-            ValidIssuer = "https://localhost:7088",
+            ValidIssuer = "https://localhost:5001",
             ValidateAudience = true,
             ValidAudience = "andy-docs-api",
             ValidateLifetime = true,
@@ -495,7 +495,7 @@ app.Run();
   },
   "AndyAuth": {
     "Provider": "AndyAuth",
-    "Authority": "https://localhost:7088",
+    "Authority": "https://localhost:5001",
     "Audience": "andy-docs-api",
     "RequireHttpsMetadata": false
   },
@@ -529,7 +529,7 @@ app.Run();
 ```bash
 cd ../andy-auth/src/Andy.Auth.Server
 dotnet run
-# Server runs at https://localhost:7088
+# Server runs at https://localhost:5001
 ```
 
 ### 2. Start Andy Docs API
@@ -543,7 +543,7 @@ dotnet run
 ### 3. Get Access Token
 
 Visit Andy.Auth.Server and login:
-- URL: https://localhost:7088/Account/Login
+- URL: https://localhost:5001/Account/Login
 - Email: test@andy.local
 - Password: Test123!
 
@@ -551,7 +551,7 @@ Or use OAuth flow:
 
 ```bash
 # Authorization Code Flow (with PKCE)
-curl -X POST "https://localhost:7088/connect/token" \
+curl -X POST "https://localhost:5001/connect/token" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=authorization_code" \
   -d "code=YOUR_AUTH_CODE" \
@@ -626,7 +626,7 @@ No code changes required!
 ```json
 {
   "AndyAuth": {
-    "Authority": "https://localhost:7088"
+    "Authority": "https://localhost:5001"
   }
 }
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ This directory contains example applications demonstrating how to integrate Andy
 
 All examples require:
 
-1. Andy Auth server running (default: https://localhost:7088)
+1. Andy Auth server running (default: https://localhost:5001)
 2. A registered OAuth client (or use Dynamic Client Registration)
 
 ## Quick Start
@@ -29,7 +29,7 @@ Before running any example, register an OAuth client in Andy Auth:
 
 **Option A: Using Dynamic Client Registration (DCR)**
 ```bash
-curl -X POST https://localhost:7088/connect/register \
+curl -X POST https://localhost:5001/connect/register \
   -H "Content-Type: application/json" \
   -d '{
     "client_name": "My Example App",
@@ -41,7 +41,7 @@ curl -X POST https://localhost:7088/connect/register \
 ```
 
 **Option B: Using the Admin Dashboard**
-1. Go to https://localhost:7088/admin/clients
+1. Go to https://localhost:5001/admin/clients
 2. Click "Add Client"
 3. Configure redirect URIs and grant types
 
@@ -50,7 +50,7 @@ curl -X POST https://localhost:7088/connect/register \
 Each example uses environment variables for configuration:
 
 ```bash
-export ANDY_AUTH_SERVER=https://localhost:7088
+export ANDY_AUTH_SERVER=https://localhost:5001
 export CLIENT_ID=your-client-id
 export CLIENT_SECRET=your-client-secret
 ```

--- a/examples/csharp-web/README.md
+++ b/examples/csharp-web/README.md
@@ -5,7 +5,7 @@ This example demonstrates how to integrate Andy Auth with a .NET 8 web applicati
 ## Prerequisites
 
 - .NET 8 SDK
-- Andy Auth server running (default: https://localhost:7088)
+- Andy Auth server running (default: https://localhost:5001)
 
 ## Setup
 
@@ -15,7 +15,7 @@ This example demonstrates how to integrate Andy Auth with a .NET 8 web applicati
 ```json
 {
   "AndyAuth": {
-    "Authority": "https://localhost:7088",
+    "Authority": "https://localhost:5001",
     "ClientId": "my-csharp-app",
     "ClientSecret": "your-client-secret"
   }

--- a/examples/go-oauth/README.md
+++ b/examples/go-oauth/README.md
@@ -5,7 +5,7 @@ This example demonstrates how to integrate Andy Auth with a Go application using
 ## Prerequisites
 
 - Go 1.21+
-- Andy Auth server running (default: https://localhost:7088)
+- Andy Auth server running (default: https://localhost:5001)
 
 ## Setup
 
@@ -14,7 +14,7 @@ This example demonstrates how to integrate Andy Auth with a Go application using
 2. Set environment variables (optional):
 
 ```bash
-export ANDY_AUTH_SERVER=https://localhost:7088
+export ANDY_AUTH_SERVER=https://localhost:5001
 export CLIENT_ID=my-go-app
 export CLIENT_SECRET=your-client-secret
 export REDIRECT_URL=http://localhost:8080/callback

--- a/examples/java-spring/README.md
+++ b/examples/java-spring/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to integrate Andy Auth with a Spring Boot applicat
 
 - Java 17+
 - Maven 3.8+
-- Andy Auth server running (default: https://localhost:7088)
+- Andy Auth server running (default: https://localhost:5001)
 
 ## Setup
 
@@ -15,7 +15,7 @@ This example demonstrates how to integrate Andy Auth with a Spring Boot applicat
 2. Set environment variables (optional):
 
 ```bash
-export ANDY_AUTH_SERVER=https://localhost:7088
+export ANDY_AUTH_SERVER=https://localhost:5001
 export CLIENT_ID=my-java-app
 export CLIENT_SECRET=your-client-secret
 ```

--- a/examples/javascript-express/README.md
+++ b/examples/javascript-express/README.md
@@ -5,7 +5,7 @@ This example demonstrates how to integrate Andy Auth with a Node.js Express appl
 ## Prerequisites
 
 - Node.js 18+
-- Andy Auth server running (default: https://localhost:7088)
+- Andy Auth server running (default: https://localhost:5001)
 
 ## Setup
 
@@ -21,7 +21,7 @@ npm install
 3. Set environment variables (optional):
 
 ```bash
-export ANDY_AUTH_SERVER=https://localhost:7088
+export ANDY_AUTH_SERVER=https://localhost:5001
 export CLIENT_ID=my-js-app
 export CLIENT_SECRET=
 export REDIRECT_URI=http://localhost:3000/callback

--- a/examples/python-flask/README.md
+++ b/examples/python-flask/README.md
@@ -5,7 +5,7 @@ This example demonstrates how to integrate Andy Auth with a Python Flask applica
 ## Prerequisites
 
 - Python 3.10+
-- Andy Auth server running (default: https://localhost:7088)
+- Andy Auth server running (default: https://localhost:5001)
 
 ## Setup
 
@@ -28,7 +28,7 @@ pip install -r requirements.txt
 4. Set environment variables (optional):
 
 ```bash
-export ANDY_AUTH_SERVER=https://localhost:7088
+export ANDY_AUTH_SERVER=https://localhost:5001
 export CLIENT_ID=my-python-app
 export REDIRECT_URI=http://localhost:5000/callback
 export SECRET_KEY=your-secret-key

--- a/examples/rust-oauth/README.md
+++ b/examples/rust-oauth/README.md
@@ -5,7 +5,7 @@ This example demonstrates how to integrate Andy Auth with a Rust application usi
 ## Prerequisites
 
 - Rust 1.70+
-- Andy Auth server running (default: https://localhost:7088)
+- Andy Auth server running (default: https://localhost:5001)
 
 ## Setup
 
@@ -14,7 +14,7 @@ This example demonstrates how to integrate Andy Auth with a Rust application usi
 2. Set environment variables (optional):
 
 ```bash
-export ANDY_AUTH_SERVER=https://localhost:7088
+export ANDY_AUTH_SERVER=https://localhost:5001
 export CLIENT_ID=my-rust-app
 export CLIENT_SECRET=your-client-secret
 export REDIRECT_URL=http://localhost:3000/callback

--- a/examples/typescript-express/README.md
+++ b/examples/typescript-express/README.md
@@ -5,7 +5,7 @@ This example demonstrates how to integrate Andy Auth with a Node.js Express appl
 ## Prerequisites
 
 - Node.js 18+
-- Andy Auth server running (default: https://localhost:7088)
+- Andy Auth server running (default: https://localhost:5001)
 
 ## Setup
 
@@ -21,7 +21,7 @@ npm install
 3. Set environment variables (optional):
 
 ```bash
-export ANDY_AUTH_SERVER=https://localhost:7088
+export ANDY_AUTH_SERVER=https://localhost:5001
 export CLIENT_ID=my-ts-app
 export REDIRECT_URI=http://localhost:3000/callback
 ```


### PR DESCRIPTION
## Summary

- Update `https://localhost:7088` references to the canonical `https://localhost:5001` across `README.md`, `docs/ARCHITECTURE.md`, `docs/ADMIN.md`, `docs/LIBRARY.md`, and the `examples/*/README.md` files. The actual server listens on `5001` per `src/Andy.Auth.Server/Properties/launchSettings.json` and `config/registration.json`.
- Fix the case-sensitive link in `README.md` (`TESTING.md` → `docs/testing.md`).
- Fix the misspelled `examples/Andy DocsIntegration/` (with a space) → `examples/AndyDocsIntegration/` in `docs/LIBRARY.md`.
- Replace the stale "54/54 tests passing" claim in `README.md` with a pointer to `docs/testing.md`, which is the maintained source.

## Test plan

- [ ] Verify all replaced links resolve.
- [ ] Verify referenced ports match `config/registration.json` and `launchSettings.json`.