### PR TITLE
[help] French translation of docs/help/overview.md (HC.4.4 of rivoli-ai/conductor#1245)

### DIFF
--- a/docs/help/overview.fr.md
+++ b/docs/help/overview.fr.md
@@ -1,0 +1,38 @@
+---
+title: Présentation d'Andy Auth
+slug: andy-auth-overview
+order: 1
+tags: [auth, identity, oidc]
+---
+
+# Présentation d'Andy Auth
+
+Andy Auth est le fournisseur d'identité OAuth2/OIDC de l'écosystème Andy. Il prend en charge l'identité utilisateur, les sessions, l'authentification multi-facteurs et l'enregistrement des clients OAuth, et constitue le serveur d'autorisation basé sur OpenIddict auquel chaque autre service Andy fait confiance.
+
+## Ce qu'il fait
+
+- Émet des jetons d'accès et de rafraîchissement pour les sessions humaines et les clients machine-à-machine (M2M).
+- Héberge le document de découverte à `/auth/.well-known/openid-configuration` pour que les autres services localisent l'émetteur, le JWKS et les scopes pris en charge sans configuration statique.
+- Gère les enregistrements de clients OAuth — chaque service qui émet ou accepte des jetons possède une entrée client ici.
+- Applique les défis MFA (TOTP aujourd'hui ; passkey/WebAuthn dans la feuille de route).
+- Publie les événements de session sur NATS pour que les services dépendants réagissent à la déconnexion et à la révocation.
+
+## Concepts clés
+
+- **Audience** — chaque API a une audience URN (`urn:andy-rbac-api`, `urn:andy-tasks-api`, …). Les jetons sont émis pour une audience spécifique et rejetés par toute autre.
+- **Scopes** — permissions fines à l'intérieur d'une audience, comme `tasks:write` ou `rbac:roles:assign`.
+- **Client M2M** — identifiants service-à-service, distincts des sessions utilisateur. Conductor lit les secrets des clients M2M via `andy-settings`.
+
+## Où il s'intègre
+
+Tous les autres services dépendent d'Andy Auth pour valider les jetons bearer. Andy Auth lui-même ne dépend que de sa propre base de données PostgreSQL. Si Auth tombe, chaque endpoint protégé du parc se met à renvoyer 401.
+
+## Configuration
+
+Les clés de fournisseur, les URL de rappel autorisées et la politique MFA résident dans `config/registration.json`. Conductor expose le catalogue en lecture seule sous **Réglages → Catalogues → Services → Andy Auth**.
+
+## Dépannage
+
+- **Erreurs IDX10*** dans les logs de service — la validation JWT a échoué. Le plus souvent l'audience ou l'émetteur ne correspond pas ; vérifiez le réglage `Authentication:Authority` du service consommateur par rapport au document de découverte d'Auth.
+- **`[API-AUTH-401]` répété dans les logs Conductor** — le jeton d'accès en cache a expiré et le rafraîchissement a échoué. Une nouvelle connexion débloque généralement ; les échecs persistants pointent vers un décalage d'horloge entre Conductor et Auth.
+- **Erreurs `IDS2*`** — OpenIddict a rejeté la forme de la requête. Le code d'erreur indique exactement quel paramètre est manquant ou mal formé.


### PR DESCRIPTION
## Summary
Adds `docs/help/overview.fr.md` — the French translation of `overview.md` shipped under HC.1.3. Mirrors the existing English structure (What it does / Key concepts / Where it fits / Configuration / Troubleshooting).

## Why
HC.4.4 of the Conductor HC epic (rivoli-ai/conductor#1245) calls for a translation pipeline for narrative `.md` articles authored in each service repo. The Conductor side already supports it (HC.4.1 ingest convention + HC.4.2 multilingual embedder + HC.4.3 locale-aware UX). This PR is the per-service proof-of-concept — drop a `<basename>.<locale>.md` sibling, and `NarrativeHelpIngest.peelLocaleSuffix` automatically tags the article with `locale=fr` so `HelpCorpus.filtered(forLocale:)` serves it when the user's Help language is French.

## Format
Same YAML front-matter shape as the English `overview.md`, with `title:` and body in French. No `locale:` front-matter needed — the filename suffix is recognised automatically.

## Next locales
The pipeline is the same for every other locale Conductor supports: drop `overview.<code>.md` for any of `de`, `es`, `it`, `ja`, `ko`, `nl`, `pl`, `pt-BR`, `ru`, `tr`, `zh-Hans` and it lands in the Help corpus automatically once Conductor rebuilds.

## Test plan
- [x] Markdown lints (no broken front-matter, no malformed YAML)
- [ ] After Conductor rebuild via `scripts/build-all-services.sh`, the French overview appears in Conductor's Help window when **Settings → Help → Language** is set to Français (or system locale is fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
