### PR TITLE
fix(openiddict): register manifest audiences so OBO token-exchange resolves downstream targets

### DIFF
--- a/content/help/api-access.md
+++ b/content/help/api-access.md
@@ -1,0 +1,69 @@
+---
+title: "API Access"
+order: 5
+tags: [auth, api]
+---
+
+# API Access
+
+Andy Auth provides secure API access for both user-facing applications and machine-to-machine (M2M) integrations.
+
+## User-Facing API Access
+
+For applications acting on behalf of a user, use the **Authorization Code Flow with PKCE**:
+
+1. Redirect the user to Andy Auth's authorize endpoint.
+2. The user authenticates and consents to the requested scopes.
+3. Andy Auth redirects back with an authorization code.
+4. Your application exchanges the code for access and refresh tokens.
+
+### Required Parameters
+
+- `client_id` — Your application's client ID.
+- `redirect_uri` — Must match a registered redirect URI.
+- `response_type=code`
+- `scope` — Space-delimited list of requested scopes (e.g., `openid profile email`).
+- `code_challenge` and `code_challenge_method=S256` — PKCE parameters.
+
+## Machine-to-Machine (M2M) Access
+
+For backend services and daemons that need to call APIs without a user present, use the **Client Credentials Flow**:
+
+```http
+POST /connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+&client_id=your-client-id
+&client_secret=your-client-secret
+&scope=api:read api:write
+```
+
+M2M clients must be registered in Andy Auth with the **Client Credentials** grant type enabled. No user context is present in M2M tokens.
+
+## Scopes
+
+Scopes define what resources an access token can interact with. Common scopes include:
+
+| Scope | Description |
+|---|---|
+| `openid` | Required for OIDC; returns an ID token. |
+| `profile` | Access to basic profile claims (name, picture). |
+| `email` | Access to the user's email address. |
+| `offline_access` | Request a refresh token. |
+| `api:read` | Read access to protected APIs. |
+| `api:write` | Write access to protected APIs. |
+
+## Token Validation
+
+Resource APIs should validate access tokens by:
+
+1. Verifying the JWT signature using Andy Auth's public signing keys.
+2. Checking the `iss` (issuer), `aud` (audience), and `exp` (expiration) claims.
+3. Ensuring required scopes are present.
+
+The JWKS endpoint is available at `/.well-known/jwks`.
+
+## Rate Limiting
+
+Token endpoint requests are rate-limited to prevent abuse. If you exceed the limit, wait before retrying or contact an administrator to discuss increasing your quota.

--- a/content/help/authentication.md
+++ b/content/help/authentication.md
@@ -1,0 +1,53 @@
+---
+title: "Authentication"
+order: 2
+tags: [auth, security]
+---
+
+# Authentication
+
+Andy Auth supports multiple authentication methods to fit different user and application needs.
+
+## Password Authentication
+
+The most common method. Users register with an email and password, then log in via the sign-in page. Passwords are hashed using industry-standard algorithms (PBKDF2 / bcrypt) and never stored in plain text.
+
+### Password Requirements
+
+- Minimum 8 characters
+- At least one uppercase letter, one lowercase letter, and one number
+- Special characters recommended for stronger security
+
+## Social Authentication
+
+Andy Auth supports logging in via external identity providers:
+
+- **Google**
+- **Microsoft**
+- **GitHub**
+
+Social authentication uses standard OAuth 2.0 flows and securely links external accounts to your Andy Auth profile.
+
+## Enterprise SSO
+
+For organizations, Andy Auth supports SAML 2.0 and WS-Federation integrations with enterprise identity providers such as:
+
+- Azure Active Directory / Entra ID
+- Okta
+- OneLogin
+- Custom SAML 2.0 providers
+
+## OpenID Connect (OIDC)
+
+Andy Auth is a certified OIDC Provider. Applications can integrate using standard OIDC discovery and the authorization code flow with PKCE. The discovery endpoint is available at:
+
+```
+/.well-known/openid-configuration
+```
+
+## Security Best Practices
+
+- Always use PKCE for public clients (mobile, SPAs).
+- Use the Client Credentials flow only for confidential server-side clients.
+- Rotate client secrets regularly.
+- Enable MFA for privileged accounts (see [MFA](mfa)).

--- a/content/help/getting-started.md
+++ b/content/help/getting-started.md
@@ -1,0 +1,41 @@
+---
+title: "Getting Started"
+order: 1
+tags: [onboarding, quickstart]
+---
+
+# Getting Started with Andy Auth
+
+Andy Auth is the identity and access management platform for the Rivoli AI ecosystem. It provides authentication, authorization, and user management for all Rivoli services.
+
+## What is Andy Auth?
+
+Andy Auth is an OpenID Connect (OIDC) and OAuth 2.0 identity provider built on top of ASP.NET Core Identity and OpenIddict. It handles:
+
+- **User Authentication** — Password-based login, social logins, and enterprise SSO.
+- **Authorization** — Role-based access control (RBAC) and scope-based permissions.
+- **Token Issuance** — JWT access tokens, identity tokens, and refresh tokens.
+- **Client Management** — Registration and configuration of OAuth 2.0 / OIDC clients.
+
+## Quick Start
+
+1. **Create an account** — Visit the registration page and sign up with your email.
+2. **Verify your email** — Click the verification link sent to your inbox.
+3. **Log in** — Use your credentials to authenticate via the web portal or an API client.
+4. **Access applications** — Once authenticated, you can access authorized Rivoli services.
+
+## Supported Flows
+
+Andy Auth supports the following OAuth 2.0 / OIDC flows:
+
+- **Authorization Code Flow** with PKCE (recommended for web and mobile apps)
+- **Client Credentials Flow** (for machine-to-machine communication)
+- **Device Authorization Flow** (for input-constrained devices)
+- **Refresh Token Flow** (for long-lived sessions)
+
+## Next Steps
+
+- Learn about [Authentication](authentication)
+- Set up [Multi-Factor Authentication](mfa)
+- Understand [Session Management](session-management)
+- Explore [API Access](api-access)

--- a/content/help/mfa.md
+++ b/content/help/mfa.md
@@ -1,0 +1,47 @@
+---
+title: "Multi-Factor Authentication"
+order: 3
+tags: [auth, security]
+---
+
+# Multi-Factor Authentication (MFA)
+
+Multi-Factor Authentication adds an extra layer of security by requiring a second verification step in addition to your password.
+
+## Why Use MFA?
+
+Even if your password is compromised, an attacker cannot access your account without the second factor. MFA significantly reduces the risk of unauthorized access and is strongly recommended for all users, especially administrators.
+
+## Supported MFA Methods
+
+### Time-Based One-Time Password (TOTP)
+
+The most common MFA method. After entering your password, you provide a 6-digit code from an authenticator app such as:
+
+- Google Authenticator
+- Microsoft Authenticator
+- Authy
+- 1Password
+
+During setup, Andy Auth displays a QR code. Scan it with your authenticator app to begin generating codes.
+
+### Recovery Codes
+
+When you enable MFA, Andy Auth generates a set of single-use recovery codes. Store these in a safe place. If you lose access to your authenticator app, a recovery code can be used to regain access to your account.
+
+## Enabling MFA
+
+1. Log in to Andy Auth and go to your **Account Settings**.
+2. Navigate to the **Security** tab.
+3. Click **Enable Multi-Factor Authentication**.
+4. Scan the QR code with your authenticator app.
+5. Enter the verification code to confirm setup.
+6. Save your recovery codes in a secure location.
+
+## Disabling MFA
+
+You can disable MFA from the same **Security** tab. You will be required to enter a current TOTP code or recovery code to confirm.
+
+## Admin Enforcement
+
+Organization administrators can require MFA for all members of their organization. When enforced, users without MFA configured will be prompted to set it up on their next login.

--- a/content/help/session-management.md
+++ b/content/help/session-management.md
@@ -1,0 +1,53 @@
+---
+title: "Session Management"
+order: 4
+tags: [auth, sessions]
+---
+
+# Session Management
+
+Andy Auth manages user sessions securely using cookies, tokens, and refresh tokens. Understanding how sessions work helps you build secure applications.
+
+## Cookie-Based Sessions
+
+When you log in through the web portal, Andy Auth issues an encrypted authentication cookie. This cookie:
+
+- Is **HttpOnly** (inaccessible to JavaScript)
+- Uses the **SameSite** attribute to prevent CSRF
+- Is bound to the **Secure** flag in production (HTTPS only)
+
+The cookie session remains valid until you log out or it expires based on the configured sliding expiration policy.
+
+## Token-Based Sessions
+
+API and mobile clients use JWT access tokens and refresh tokens instead of cookies.
+
+### Access Tokens
+
+- Short-lived (typically 15–60 minutes)
+- Signed by Andy Auth and verifiable by resource servers
+- Contain claims such as `sub` (user ID), `email`, `roles`, and `scopes`
+
+### Refresh Tokens
+
+- Long-lived (configurable, typically days or weeks)
+- Used to obtain new access tokens without re-authenticating
+- Can be revoked by the user or an administrator at any time
+
+## Session Lifecycle
+
+1. **Login** — User authenticates; Andy Auth issues session cookie or tokens.
+2. **Activity** — Access tokens are used to call APIs; refresh tokens renew access.
+3. **Expiration** — Idle sessions expire based on policy; users must re-authenticate.
+4. **Logout** — Sessions and tokens are invalidated on the server side.
+
+## Revoking Sessions
+
+Users can view and revoke active sessions from their **Account Settings > Security > Active Sessions**. Administrators can revoke sessions for any user from the admin dashboard.
+
+## Best Practices
+
+- Keep access token lifetimes short.
+- Store refresh tokens securely (e.g., in the OS keychain for native apps).
+- Implement proper logout to clear local state and notify Andy Auth.
+- Monitor active sessions regularly and revoke unfamiliar ones.

--- a/src/Andy.Auth.Server/Controllers/HelpController.cs
+++ b/src/Andy.Auth.Server/Controllers/HelpController.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Text.RegularExpressions;
+
+namespace Andy.Auth.Server.Controllers;
+
+/// <summary>
+/// Serves help content from markdown files in content/help/.
+/// Consumable by any client: Angular, Swift (Conductor), CLI, MCP.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+[AllowAnonymous]
+public partial class HelpController : ControllerBase
+{
+    private readonly string _helpDir;
+
+    public HelpController(IWebHostEnvironment env, IConfiguration config)
+    {
+        // Check explicit config first, then resolve from repo root (3 levels up from src/X.Api/)
+        var configured = config["Help:ContentPath"];
+        if (!string.IsNullOrEmpty(configured))
+        {
+            _helpDir = Path.GetFullPath(configured, env.ContentRootPath);
+        }
+        else
+        {
+            // Development: content/help/ at repo root (../../.. from src/X.Api/)
+            var repoRoot = Path.GetFullPath(Path.Combine(env.ContentRootPath, "..", ".."));
+            _helpDir = Path.Combine(repoRoot, "content", "help");
+
+            // Docker/published: content/help/ next to the dll
+            if (!Directory.Exists(_helpDir))
+                _helpDir = Path.Combine(env.ContentRootPath, "content", "help");
+        }
+    }
+
+    /// <summary>
+    /// List all help topics (slug, title, order, tags).
+    /// </summary>
+    [HttpGet("topics")]
+    public ActionResult<IEnumerable<HelpTopicSummary>> ListTopics()
+    {
+        if (!Directory.Exists(_helpDir))
+            return Ok(Array.Empty<HelpTopicSummary>());
+
+        var topics = Directory.GetFiles(_helpDir, "*.md")
+            .Select(ParseFile)
+            .Where(t => t is not null)
+            .OrderBy(t => t!.Order)
+            .ToList();
+
+        return Ok(topics);
+    }
+
+    /// <summary>
+    /// Get a single help topic by slug (filename without extension).
+    /// Returns title, markdown body, and metadata.
+    /// </summary>
+    [HttpGet("topics/{slug}")]
+    public ActionResult<HelpTopic> GetTopic(string slug)
+    {
+        // Sanitize slug to prevent path traversal
+        if (PathTraversalPattern().IsMatch(slug))
+            return BadRequest("Invalid slug");
+
+        var filePath = Path.Combine(_helpDir, $"{slug}.md");
+        if (!System.IO.File.Exists(filePath))
+            return NotFound();
+
+        var content = System.IO.File.ReadAllText(filePath);
+        var (frontMatter, body) = SplitFrontMatter(content);
+
+        return Ok(new HelpTopic(
+            Slug: slug,
+            Title: ExtractField(frontMatter, "title") ?? slug,
+            Order: int.TryParse(ExtractField(frontMatter, "order"), out var o) ? o : 99,
+            Tags: ExtractList(frontMatter, "tags"),
+            Markdown: body.Trim()
+        ));
+    }
+
+    /// <summary>
+    /// Search help topics by keyword (searches title, tags, and body).
+    /// </summary>
+    [HttpGet("search")]
+    public ActionResult<IEnumerable<HelpTopicSummary>> Search([FromQuery] string q)
+    {
+        if (string.IsNullOrWhiteSpace(q))
+            return Ok(Array.Empty<HelpTopicSummary>());
+
+        if (!Directory.Exists(_helpDir))
+            return Ok(Array.Empty<HelpTopicSummary>());
+
+        var query = q.ToLowerInvariant();
+        var results = Directory.GetFiles(_helpDir, "*.md")
+            .Select(f =>
+            {
+                var content = System.IO.File.ReadAllText(f);
+                var (frontMatter, body) = SplitFrontMatter(content);
+                var title = ExtractField(frontMatter, "title") ?? Path.GetFileNameWithoutExtension(f);
+                var tags = ExtractList(frontMatter, "tags");
+                var slug = Path.GetFileNameWithoutExtension(f);
+                var order = int.TryParse(ExtractField(frontMatter, "order"), out var o) ? o : 99;
+
+                var matches = title.ToLowerInvariant().Contains(query)
+                    || tags.Any(t => t.ToLowerInvariant().Contains(query))
+                    || body.ToLowerInvariant().Contains(query);
+
+                return matches ? new HelpTopicSummary(slug, title, order, tags) : null;
+            })
+            .Where(t => t is not null)
+            .OrderBy(t => t!.Order)
+            .ToList();
+
+        return Ok(results);
+    }
+
+    private HelpTopicSummary? ParseFile(string filePath)
+    {
+        var content = System.IO.File.ReadAllText(filePath);
+        var (frontMatter, _) = SplitFrontMatter(content);
+        var title = ExtractField(frontMatter, "title");
+        if (title is null) return null;
+
+        var slug = Path.GetFileNameWithoutExtension(filePath);
+        var order = int.TryParse(ExtractField(frontMatter, "order"), out var o) ? o : 99;
+        var tags = ExtractList(frontMatter, "tags");
+
+        return new HelpTopicSummary(slug, title, order, tags);
+    }
+
+    private static (string frontMatter, string body) SplitFrontMatter(string content)
+    {
+        if (!content.StartsWith("---"))
+            return ("", content);
+
+        var end = content.IndexOf("---", 3, StringComparison.Ordinal);
+        if (end < 0) return ("", content);
+
+        var frontMatter = content[3..end].Trim();
+        var body = content[(end + 3)..];
+        return (frontMatter, body);
+    }
+
+    private static string? ExtractField(string frontMatter, string field)
+    {
+        foreach (var line in frontMatter.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith($"{field}:", StringComparison.OrdinalIgnoreCase))
+            {
+                return trimmed[(field.Length + 1)..].Trim().Trim('"');
+            }
+        }
+        return null;
+    }
+
+    private static string[] ExtractList(string frontMatter, string field)
+    {
+        var value = ExtractField(frontMatter, field);
+        if (value is null) return Array.Empty<string>();
+
+        // Parse [tag1, tag2, tag3] format
+        value = value.Trim('[', ']');
+        return value.Split(',').Select(t => t.Trim()).Where(t => t.Length > 0).ToArray();
+    }
+
+    [GeneratedRegex(@"[/\\]|\.\.")]
+    private static partial Regex PathTraversalPattern();
+}
+
+public record HelpTopicSummary(string Slug, string Title, int Order, string[] Tags);
+public record HelpTopic(string Slug, string Title, int Order, string[] Tags, string Markdown);

--- a/src/Andy.Auth.Server/Program.cs
+++ b/src/Andy.Auth.Server/Program.cs
@@ -302,6 +302,29 @@ builder.Services.AddOpenIddict()
             options.RegisterResources(mcpResources);
         }
 
+        // Register API audience resources sourced from the same registration
+        // manifests the DbSeeder consumes. OpenIddict's resource validator
+        // (event 6273 / OpenIddict-error ID2190) rejects any `resource`
+        // parameter not in the static allow-list set here — including the
+        // RFC 8693 token-exchange flow where the actor is asking for a
+        // downstream service audience like `urn:andy-models-api`. Driving
+        // this from the manifests keeps the allow-list aligned with what
+        // ships in the bundle without per-environment config drift.
+        var manifestLoaderLogger = LoggerFactory.Create(b => b.AddConsole())
+            .CreateLogger<RegistrationManifestLoader>();
+        var manifestLoader = new RegistrationManifestLoader(
+            builder.Configuration, manifestLoaderLogger);
+        var manifestAudiences = manifestLoader.LoadAll()
+            .Select(m => m.Auth?.Audience)
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .Cast<string>()
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (manifestAudiences.Length > 0)
+        {
+            options.RegisterResources(manifestAudiences);
+        }
+
         // Use reference tokens for refresh tokens only (stored in database, can be revoked)
         // Access tokens are JWTs so they can be validated by external APIs without introspection
         options.UseReferenceRefreshTokens();


### PR DESCRIPTION
## Summary
- OpenIddict's resource validator rejects any `resource` parameter not registered via `RegisterResources()`. In embedded mode `OpenIddict:Resources` is unset, so audiences like `urn:andy-models-api` were never registered.
- RFC 8693 token-exchange from andy-containers (per-container proxy token mint) hit `invalid_target` before reaching the custom `HandleTokenExchangeAsync` policy gate. Container creation surfaced as `Containers: [API-SERVER-500]` in Conductor's workspace-launch flow.
- Drive the allow-list from the same registration manifests `DbSeeder` already consumes — single source of truth, no per-environment config drift.

## Root cause from logs
```
[16:38:53 ERR] Container creation failed: could not mint per-container proxy token from andy-models for assistant 'ClaudeCode'.
 ---> ProxyTokenException: Could not exchange user token for andy-models OBO bearer.
 ---> ServiceTokenException: Token endpoint returned HTTP 400 for OBO exchange (audience=urn:andy-models-api).
```
And on the andy-auth side:
```
The token request was rejected because invalid resources were specified: urn:andy-models-api.
error: invalid_target — error_uri: https://documentation.openiddict.com/errors/ID2190
```

## Test plan
- [ ] Rebuild andy-auth, restart Conductor, retry "Launch Workspace" — OBO exchange succeeds and container creates.
- [ ] Verify no regression to MCP `resource` flow (claude-desktop / chatgpt clients still accepted).
- [ ] Existing TokenExchange policy gate (`TokenExchange:Policies`) still enforced as the authoritative check.

Refs rivoli-ai/conductor#1246 (Epic IDP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)