### PR TITLE
docs: refresh markdown documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Access at: **/Admin**
 | Client | Type | Use Case |
 |--------|------|----------|
 | `andy-docs-api` | Confidential | Server-to-server communication |
-| `wagram-web` | Public SPA | Angular/React web applications |
+| `andy-docs-web` | Public SPA | Angular/React web applications (renamed from `wagram-web` per andy-auth#25) |
 | `claude-desktop` | Public | Claude Desktop MCP integration |
 | `chatgpt` | Public | ChatGPT MCP integration |
 | `cline` | Public | Cline VS Code extension |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -388,14 +388,15 @@ HTTP Request
 ## Monitoring & Observability
 
 ### Logging
-- **Serilog** (future): Structured logging
+- **Microsoft.Extensions.Logging**: Structured logging via the default ASP.NET Core providers
 - **Log Levels**: Information, Warning, Error
 - **Audit Logs**: All auth events logged to database
 
-### Metrics
+### Metrics & Tracing
 - **Health Checks**: `/health` endpoint
-- **OpenTelemetry** (future): Distributed tracing
-- **Application Insights** (future): Performance monitoring
+- **OpenTelemetry**: Wired via `Andy.Telemetry` (`Program.cs` `AddAndyTelemetry`) — traces + metrics + Prometheus scrape; OTLP exports to Conductor's local receiver at `:4318` when running embedded
+- **Custom Activity Source / Meter**: `AuthTelemetry.ActivitySourceName` / `AuthTelemetry.MeterName` (see `Telemetry/AuthTelemetry.cs`)
+- **Application Insights** (future): Hosted APM
 
 ### Alerts
 - **Railway**: Built-in monitoring

--- a/docs/ASSISTANT-INTEGRATION.md
+++ b/docs/ASSISTANT-INTEGRATION.md
@@ -353,5 +353,5 @@ To add support for a new AI assistant:
 ## Related Documentation
 
 - [Andy.Auth Architecture](./ARCHITECTURE.md)
-- [Azure AD Integration](./AZURE-AD.md)
+- [Andy.Auth Client Library (incl. Azure AD provider config)](./LIBRARY.md)
 - [Security Guide](./SECURITY.md)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -225,7 +225,11 @@ AndyAuth__Audience=andy-docs-api
 AndyAuth__RequireHttpsMetadata=true
 ```
 
-### Wagram Frontend (Vercel)
+### Andy Docs SPA (Vercel)
+
+> Historically referred to as the "Wagram frontend"; the `andy-docs-web` client
+> still keeps `docs.wagram.ai` / `docs.uat.wagram.ai` in its redirect-URI
+> allow-list (see `DbSeeder.cs`) until the public domain migration lands.
 
 **Environment Variables:**
 ```bash
@@ -389,7 +393,7 @@ railway variables --json > env-backup.json
 
 ### Client Integration
 - [ ] Andy Docs API updated
-- [ ] Wagram frontend updated
+- [ ] Andy Docs SPA (`andy-docs-web`) updated
 - [ ] Claude Desktop tested
 - [ ] All OAuth clients working
 

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -825,7 +825,7 @@ builder.Services.AddAndyAuth(options =>
 
 ## Support
 
-- **Documentation**: [docs/](../docs/)
+- **Documentation**: [docs/](./)
 - **Issues**: [GitHub Issues](https://github.com/rivoli-ai/andy-auth/issues)
 - **Server Docs**: [Andy.Auth.Server Documentation](./DEPLOYMENT.md)
 

--- a/docs/LOCAL-SETUP.md
+++ b/docs/LOCAL-SETUP.md
@@ -15,7 +15,7 @@ docker-compose up -d
 ```
 
 This starts:
-- PostgreSQL on port 5432
+- PostgreSQL on host port 7435 (mapped to container port 5432)
 - Adminer (database UI) on http://localhost:8080
 
 ### 2. Run Andy.Auth.Server
@@ -27,7 +27,7 @@ dotnet run
 
 The server will:
 - Run migrations automatically
-- Seed OAuth clients (andy-docs-api, wagram-web, claude-desktop)
+- Seed OAuth clients (andy-docs-api, andy-docs-web, claude-desktop, chatgpt, cline, roo, continue-dev, and the manifest-driven sibling-service clients)
 - Create test user: `test@andy.local` / `Test123!`
 - Start on https://localhost:5001
 
@@ -60,17 +60,21 @@ Edit `src/Andy.Auth.Server/appsettings.Development.json`:
 ```json
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Database=andy_auth_dev;Username=postgres;Password=postgres"
+    "DefaultConnection": "Host=localhost;Port=7435;Database=andy_auth_dev;Username=andy_auth;Password=andy_auth_dev_password"
   }
 }
 ```
 
+> The committed `appsettings.Development.json` already targets the docker-compose pg on host port 7435 with the `andy_auth` role.
+
 ### OAuth Clients
 
-Clients are automatically seeded on startup. Edit `src/Andy.Auth.Server/Data/DbSeeder.cs` to modify:
+Clients are automatically seeded on startup. Edit `src/Andy.Auth.Server/Data/DbSeeder.cs` to modify the hardcoded clients:
 - `andy-docs-api` - Confidential client for Andy Docs API
-- `wagram-web` - Public client for Angular frontend
+- `andy-docs-web` - Public client for the Andy Docs SPA *(renamed from `wagram-web` per andy-auth#25)*
 - `claude-desktop` - Public client for Claude Desktop MCP
+
+Additional clients (and their OAuth scopes) are auto-discovered from each sibling service's `config/registration.json` manifest at startup; only CORS allow-list origins and `OpenIddict:Resources` remain manual in `appsettings.Development.json`.
 
 ### Security Keys
 
@@ -274,7 +278,7 @@ dotnet run
 - [ ] Test with Claude Desktop MCP
 - [ ] Test with ChatGPT/Roo
 - [ ] Deploy to Railway UAT
-- [ ] Update Wagram frontend to use Andy Auth
+- [ ] Update the Andy Docs SPA (`andy-docs-web`) to use Andy Auth
 
 ## Resources
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -188,7 +188,7 @@ Before deploying to production, verify:
 - [ ] Security headers are verified using tools like securityheaders.com
 - [ ] Application is behind a reverse proxy (nginx, Caddy, etc.)
 - [ ] PostgreSQL is not exposed to the public internet
-- [ ] Admin accounts use strong passwords and 2FA (when implemented)
+- [ ] Admin accounts use strong passwords and 2FA (TOTP, via `TwoFactorController`)
 
 ## Security Testing
 

--- a/docs/presentation.md
+++ b/docs/presentation.md
@@ -65,9 +65,9 @@ andy-auth/
 ├── tests/
 │   ├── Andy.Auth.Server.Tests/    ← unit (54 tests)
 │   ├── Andy.Auth.Tests/           ← client lib tests
-│   └── Andy.Auth.E2E.Tests/       ← Playwright
-├── examples/csharp-web/           ← reference integration
-└── oauth-python/                  ← 42-test external suite
+│   ├── Andy.Auth.E2E.Tests/       ← Playwright
+│   └── oauth-python/              ← 42-test external suite
+└── examples/csharp-web/           ← reference integration
 ```
 
 6 `.csproj` in total. The client library is the integration contract.
@@ -282,9 +282,12 @@ MCP endpoint at `POST /mcp` (`Program.cs:366–368`) requires OAuth; tools provi
 
 | Port | Purpose |
 |------|---------|
-| 5001 | OAuth server HTTPS (dev) |
-| 5002 | OAuth server HTTP (dev) |
-| 5435 | PostgreSQL (docker-compose) |
+| 5001 | OAuth server HTTPS (dotnet local) |
+| 5002 | OAuth server HTTP (dotnet local) |
+| 7001 | OAuth server HTTPS (docker-compose, mapped to container 5001) |
+| 7002 | OAuth server HTTP (docker-compose, mapped to container 5000) |
+| 7435 | PostgreSQL (docker-compose, mapped to container 5432) |
+| 9100 | Conductor embedded proxy (`/auth` prefix) |
 
 Key settings:
 
@@ -306,9 +309,10 @@ Multi-stage Dockerfile:
 
 `docker-compose.yml`:
 
-- `postgres:16-alpine` with healthcheck
-- `adminer` for DB inspection
-- Auth server on `5001:5001` (HTTPS) / `5002:5000` (HTTP)
+- `postgres:16-alpine` with healthcheck (host `7435` → container `5432`)
+- `adminer` for DB inspection on `8080`
+- Auth server on `7001:5001` (HTTPS) / `7002:5000` (HTTP)
+- Sibling-service registration manifests mounted read-only at `/monorepo` so the auth seeder can auto-discover their OAuth clients + scopes.
 
 Railway production deployment supported via `PORT` env var.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -165,7 +165,7 @@ ANDY_AUTH_TEST_PASSWORD="Test123!" python3 run_all_tests.py --env uat --html rep
 
 **OAuth Clients:**
 - `andy-docs-api` - Confidential client with secret
-- `wagram-web` - Public SPA client
+- `andy-docs-web` - Public SPA client *(renamed from `wagram-web` per andy-auth#25)*
 - `claude-desktop` - Public desktop client
 
 ## Environment Configuration


### PR DESCRIPTION
## Summary

- Update seeded-clients tables and prose references where `wagram-web` was renamed to `andy-docs-web` (andy-auth#25): README, LOCAL-SETUP, testing, presentation.
- LOCAL-SETUP: fix the PostgreSQL port (host 7435 per `docker-compose.yml`), connection-string example (`andy_auth` role), and the list of clients the seeder creates (chatgpt/cline/roo/continue-dev + manifest-driven sibling clients via `config/registration.json` auto-discovery; CORS + `OpenIddict:Resources` stay manual).
- presentation.md: fix the port table (7001/7002/7435 host ports + 9100 embedded proxy), move `oauth-python/` under `tests/` to match the actual layout, note the `/monorepo` registration-manifest mount.
- ARCHITECTURE: drop the "(future)" qualifier from OpenTelemetry — it's wired via `Andy.Telemetry` (OT4–OT16); default logging is Microsoft.Extensions.Logging, not Serilog.
- SECURITY: 2FA is shipped (`TwoFactorController`), not pending.
- ASSISTANT-INTEGRATION: kill the broken `./AZURE-AD.md` link and point at LIBRARY.md where the Azure AD provider config lives.
- DEPLOYMENT: rename "Wagram Frontend" section to "Andy Docs SPA" and flag the surviving `docs.wagram.ai` redirect URIs in `DbSeeder.cs`.
- LIBRARY: fix the broken `../docs/` self-link.

No new docs, no reorgs, no non-markdown edits.

## Test plan

- [ ] Reviewer reads the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)