### PR TITLE
fix(m2m): budget-driven cold-start retry for M2M token fetch (conductor#1902)

### DIFF
--- a/src/Andy.Auth.M2MClient/AndyAuthM2MOptions.cs
+++ b/src/Andy.Auth.M2MClient/AndyAuthM2MOptions.cs
@@ -46,6 +46,32 @@ public sealed class AndyAuthM2MOptions
     /// </summary>
     public string? Scope { get; set; }
 
+    /// <summary>
+    /// Maximum total wall-clock the token provider keeps retrying
+    /// <em>transient</em> token-endpoint failures (connection-refused /
+    /// DNS / TLS, and gateway 502/503/504/408/429) before giving up and
+    /// surfacing the last error.
+    ///
+    /// Covers the embedded full-fleet cold start (conductor#1902): every
+    /// service spawned in the application wave dials andy-auth for an M2M
+    /// token within milliseconds of its own start, but the route to
+    /// andy-auth through Conductor's UnifiedProxy (e.g.
+    /// <c>http://localhost:9100/auth/connect/token</c>) may not be live
+    /// for tens of seconds after this service starts (postgres + zot +
+    /// nats + andy-auth migration all have to complete first). With the
+    /// budget set generously the fetch succeeds on a later attempt
+    /// instead of exhausting — so the caller never sees an exception to
+    /// log, and the planner gets its real settings rather than degrading.
+    ///
+    /// Bounded so a genuinely-misconfigured deployment (wrong endpoint,
+    /// auth permanently down) still fails fast-ish rather than hanging
+    /// forever. The success path returns as soon as auth is reachable
+    /// (typically a few seconds), so this is only the worst-case wait.
+    /// Set to <see cref="TimeSpan.Zero"/> to disable retries entirely
+    /// (first failure propagates immediately).
+    /// </summary>
+    public TimeSpan StartupRetryBudget { get; set; } = TimeSpan.FromSeconds(30);
+
     /// <summary>True when M2M outbound auth is configured.</summary>
     public bool IsEnabled =>
         !string.IsNullOrWhiteSpace(ClientId) &&

--- a/src/Andy.Auth.M2MClient/ClientCredentialsTokenProvider.cs
+++ b/src/Andy.Auth.M2MClient/ClientCredentialsTokenProvider.cs
@@ -108,49 +108,73 @@ public sealed class ClientCredentialsTokenProvider : IRefreshableServiceTokenPro
     }
 
     /// <summary>
-    /// Retry schedule used when the token endpoint returns a transient
-    /// failure (502/503/504 / connection refused / DNS / TLS errors).
-    /// Total wall-clock ~7.7s before giving up — long enough to cover
-    /// andy-auth's typical cold-start, short enough to fail fast on
-    /// genuinely-misconfigured deployments.
-    ///
-    /// Cold-start race documented at conductor#XXXX (PV epic): every
-    /// service spawned in the application wave hits andy-auth for an
-    /// M2M token within milliseconds of its own start; if andy-auth
-    /// hasn't bound its listener yet the proxy returns 502 and the
-    /// caller's hosted bootstrapper (e.g.
-    /// <c>PlannerSettingsBootstrapper</c>) calls
-    /// <c>StopApplication</c>. The retry collapses that race onto a
-    /// successful second-or-third attempt without flapping.
+    /// Capped exponential backoff for transient token-endpoint failures
+    /// (502/503/504/408/429 / connection refused / DNS / TLS errors).
+    /// The number of attempts is bounded by
+    /// <see cref="AndyAuthM2MOptions.StartupRetryBudget"/> rather than a
+    /// fixed count, so the same schedule covers both a fast standalone
+    /// restart and a slow embedded full-fleet cold start (conductor#1902)
+    /// without flapping. Steps cap at 5s so a long budget doesn't sit
+    /// idle between probes.
     /// </summary>
-    private static readonly TimeSpan[] RetryBackoffs =
+    private static TimeSpan BackoffFor(int attempt) => attempt switch
     {
-        TimeSpan.FromMilliseconds(200),
-        TimeSpan.FromMilliseconds(500),
-        TimeSpan.FromSeconds(1),
-        TimeSpan.FromSeconds(2),
-        TimeSpan.FromSeconds(4),
+        0 => TimeSpan.FromMilliseconds(200),
+        1 => TimeSpan.FromMilliseconds(500),
+        2 => TimeSpan.FromSeconds(1),
+        3 => TimeSpan.FromSeconds(2),
+        4 => TimeSpan.FromSeconds(4),
+        _ => TimeSpan.FromSeconds(5),
     };
 
     private async Task<string> FetchAsync(CancellationToken ct)
     {
-        Exception? lastTransient = null;
-        for (var attempt = 0; attempt <= RetryBackoffs.Length; attempt++)
+        // Retry transient failures until the *planned* cumulative delay
+        // would exceed the configured budget. We sum planned delays
+        // rather than read a clock so the decision is deterministic and
+        // unit-testable (a tiny budget => fail fast; a generous one =>
+        // ride out a cold start). conductor#1902.
+        var budget = _options.StartupRetryBudget;
+        ServiceTokenException? lastTransient = null;
+        var planned = TimeSpan.Zero;
+        var attempt = 0;
+        while (true)
         {
             try
             {
                 return await FetchOnceAsync(ct).ConfigureAwait(false);
             }
-            catch (ServiceTokenException ex) when (IsTransient(ex) && attempt < RetryBackoffs.Length)
+            catch (ServiceTokenException ex) when (IsTransient(ex))
             {
                 lastTransient = ex;
-                _logger.LogDebug(
-                    "M2M token fetch attempt {Attempt}/{Total} failed transiently ({Code}); retrying in {Delay}ms",
-                    attempt + 1,
-                    RetryBackoffs.Length + 1,
-                    ExtractCode(ex),
-                    RetryBackoffs[attempt].TotalMilliseconds);
-                await Task.Delay(RetryBackoffs[attempt], ct).ConfigureAwait(false);
+                var delay = BackoffFor(attempt);
+                if (planned + delay > budget)
+                {
+                    // Budget exhausted (or retries disabled, budget == 0):
+                    // stop and surface the last error below.
+                    break;
+                }
+
+                if (attempt == 0)
+                {
+                    // ONE friendly line on the first miss instead of a
+                    // full exception stack per attempt — this is the
+                    // expected cold-start path, not an error yet.
+                    _logger.LogInformation(
+                        "[M2M-TOKEN-UNREACHABLE] {Code} on first token fetch from {Endpoint}; " +
+                        "retrying up to {Budget:0.#}s (likely cold start).",
+                        ExtractCode(ex), _options.ResolveTokenEndpoint(), budget.TotalSeconds);
+                }
+                else
+                {
+                    _logger.LogDebug(
+                        "M2M token fetch retry {Attempt} failed transiently ({Code}); next in {Delay}ms",
+                        attempt + 1, ExtractCode(ex), delay.TotalMilliseconds);
+                }
+
+                await Task.Delay(delay, ct).ConfigureAwait(false);
+                planned += delay;
+                attempt++;
             }
         }
         // All retries exhausted on transient failures — surface the

--- a/tests/Andy.Auth.M2MClient.Tests/ClientCredentialsTokenProviderTests.cs
+++ b/tests/Andy.Auth.M2MClient.Tests/ClientCredentialsTokenProviderTests.cs
@@ -135,12 +135,68 @@ public sealed class ClientCredentialsTokenProviderTests
     {
         var handler = new StubHandler((_, _) =>
             Task.FromException<HttpResponseMessage>(new HttpRequestException("connect failed")));
-        using var provider = NewProvider(handler, new FakeTimeProvider());
+        // Budget zero => retries disabled, first failure propagates
+        // immediately (keeps this test fast and asserts the give-up path).
+        using var provider = NewProvider(handler, new FakeTimeProvider(),
+            startupRetryBudget: TimeSpan.Zero);
 
         var ex = await Assert.ThrowsAsync<ServiceTokenException>(() =>
             provider.GetTokenAsync(CancellationToken.None));
         Assert.Contains("[M2M-TOKEN-UNREACHABLE]", ex.Message);
         Assert.IsType<HttpRequestException>(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_RetriesTransientFailure_ThenSucceeds()
+    {
+        // conductor#1902: under the embedded daemon the proxy route to
+        // andy-auth is connection-refused for the first few probes after
+        // this service starts. With a budget the provider must ride that
+        // out and succeed on a later attempt rather than throwing.
+        var calls = 0;
+        var handler = new StubHandler((_, _) =>
+        {
+            calls++;
+            if (calls < 3)
+            {
+                return Task.FromException<HttpResponseMessage>(
+                    new HttpRequestException("Connection refused (localhost:9100)"));
+            }
+            return Task.FromResult(TokenResponse("late", expiresIn: 3600));
+        });
+        // Generous budget; the first two backoffs (200ms + 500ms) are
+        // well within it, so this completes in <1s of real time.
+        using var provider = NewProvider(handler, new FakeTimeProvider(),
+            startupRetryBudget: TimeSpan.FromSeconds(30));
+
+        var token = await provider.GetTokenAsync(CancellationToken.None);
+
+        Assert.Equal("late", token);
+        Assert.Equal(3, calls);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ExhaustsBudget_ThenThrowsLastTransient()
+    {
+        // Always-refused with a tiny budget: exactly the first backoff
+        // (200ms) fits, so one retry happens, then the budget is exceeded
+        // and the last [M2M-TOKEN-UNREACHABLE] surfaces.
+        var calls = 0;
+        var handler = new StubHandler((_, _) =>
+        {
+            calls++;
+            return Task.FromException<HttpResponseMessage>(
+                new HttpRequestException("Connection refused"));
+        });
+        using var provider = NewProvider(handler, new FakeTimeProvider(),
+            startupRetryBudget: TimeSpan.FromMilliseconds(300));
+
+        var ex = await Assert.ThrowsAsync<ServiceTokenException>(() =>
+            provider.GetTokenAsync(CancellationToken.None));
+        Assert.Contains("[M2M-TOKEN-UNREACHABLE]", ex.Message);
+        // Initial attempt + one retry (200ms <= 300ms budget); the next
+        // backoff (500ms) would exceed the budget, so we stop at 2 calls.
+        Assert.Equal(2, calls);
     }
 
     [Fact]
@@ -250,7 +306,8 @@ public sealed class ClientCredentialsTokenProviderTests
     }
 
     private static ClientCredentialsTokenProvider NewProvider(
-        HttpMessageHandler handler, TimeProvider time, string? scope = null)
+        HttpMessageHandler handler, TimeProvider time, string? scope = null,
+        TimeSpan? startupRetryBudget = null)
     {
         var http = new HttpClient(handler);
         var factory = new SingleClientFactory(http);
@@ -260,6 +317,9 @@ public sealed class ClientCredentialsTokenProviderTests
             ClientId = ClientId,
             ClientSecretEnvVar = EnvVar,
             Scope = scope,
+            // Default to no-retry in tests so the happy-path / error-path
+            // cases stay fast; retry-specific tests opt into a budget.
+            StartupRetryBudget = startupRetryBudget ?? TimeSpan.Zero,
         });
         return new ClientCredentialsTokenProvider(
             factory, options, time, NullLogger<ClientCredentialsTokenProvider>.Instance);


### PR DESCRIPTION
Refs rivoli-ai/conductor#1902.

## Problem

Under the embedded conductord daemon, every service dials andy-auth for an M2M token within milliseconds of its own start, but the route to andy-auth through the UnifiedProxy (`localhost:9100/auth/connect/token`) isn't live until postgres + zot + nats + andy-auth's migration all finish — often longer than the old fixed **~7.7s** retry window. When that window exhausted, `ClientCredentialsTokenProvider` threw `[M2M-TOKEN-UNREACHABLE]`, and the caller's hosted bootstrapper (e.g. andy-tasks `PlannerSettingsBootstrapper`) logged a full `crit:` exception stack before degrading — scary noise on every cold start even though the service recovered.

## Fix (option 2 from the issue)

- **`AndyAuthM2MOptions.StartupRetryBudget`** (default **30s**, configurable; `0` = no retry). The retry loop backs off `200ms → 500ms → 1s → 2s → 4s → 5s` (capped) and keeps going until the *planned* cumulative delay would exceed the budget, instead of a fixed 5-attempt count. The fetch now **succeeds on a later attempt** once the proxy route is live, so the caller never sees an exception and the planner gets real settings instead of degrading. The success path returns as soon as auth is reachable (a few seconds) — the budget is only the worst-case wait, and stays bounded so a genuinely-misconfigured endpoint still fails.
- **First transient miss logs ONE `Information` line** (`[M2M-TOKEN-UNREACHABLE] ... retrying up to Ns (likely cold start)`) instead of a per-attempt stack; subsequent retries log at `Debug`.

## Tests

Summing *planned* delays (not a wall clock) keeps the retry decision deterministic and fast to test. **13/13 pass in <1s**:
- `GetTokenAsync_RetriesTransientFailure_ThenSucceeds` — fails twice (connection-refused), succeeds on the 3rd attempt.
- `GetTokenAsync_ExhaustsBudget_ThenThrowsLastTransient` — tiny budget => exactly one retry, then surfaces the last `[M2M-TOKEN-UNREACHABLE]`.
- Existing unreachable test pinned to budget `0` so it stays fast (and asserts the give-up path).

## Rollout note

This is a NuGet-packaged client (`Andy.Auth.M2MClient`). Landing the behaviour in the running embedded daemon requires repacking the package and bumping the consuming services' references — tracked alongside the M2M-consumer rollout (#990). The default 30s budget means no config change is needed by consumers to benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)