### PR TITLE
Accept subject-token issuer with or without trailing slash (OBO exchange fix)

### DIFF
--- a/src/Andy.Auth.Server/Services/SubjectTokenValidator.cs
+++ b/src/Andy.Auth.Server/Services/SubjectTokenValidator.cs
@@ -76,7 +76,17 @@ public class InProcessSubjectTokenValidator : ISubjectTokenValidator
         var validationParameters = new TokenValidationParameters
         {
             ValidateIssuer = true,
-            ValidIssuer = options.Issuer.ToString().TrimEnd('/'),
+            // Accept the issuer both with and without a trailing slash. OpenIddict
+            // issues the `iss` claim verbatim from the configured issuer URI, which
+            // carries a trailing slash (e.g. "http://localhost:9100/auth/"), while a
+            // single trimmed ValidIssuer ("…/auth") is an exact-match miss → the
+            // subject_token is rejected and the whole OBO exchange fails with
+            // invalid_grant (rivoli-ai/conductor#1973). List both normalized forms.
+            ValidIssuers = new[]
+            {
+                options.Issuer.ToString(),
+                options.Issuer.ToString().TrimEnd('/'),
+            },
             ValidateAudience = false,
             ValidateLifetime = true,
             ValidateIssuerSigningKey = true,

--- a/tests/Andy.Auth.Server.Tests/SubjectTokenValidatorIssuerTests.cs
+++ b/tests/Andy.Auth.Server.Tests/SubjectTokenValidatorIssuerTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using Andy.Auth.Server.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Server;
+using Xunit;
+
+namespace Andy.Auth.Server.Tests;
+
+/// <summary>
+/// Regression guard for rivoli-ai/conductor#1973: the RFC 8693 subject-token
+/// validator must accept the `iss` claim whether or not it carries a trailing
+/// slash. OpenIddict emits `iss` verbatim from the configured issuer URI
+/// (which has a trailing slash, e.g. "https://auth.example/"); a single
+/// trimmed ValidIssuer was an exact-match miss, rejecting every OBO exchange
+/// with invalid_grant.
+/// </summary>
+public class SubjectTokenValidatorIssuerTests
+{
+    private const string IssuerWithSlash = "https://auth.example/";
+
+    private static (InProcessSubjectTokenValidator validator, SigningCredentials creds) BuildValidator()
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('k', 64)));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var options = new OpenIddictServerOptions { Issuer = new Uri(IssuerWithSlash) };
+        options.SigningCredentials.Add(creds);
+
+        var monitor = new StaticOptionsMonitor<OpenIddictServerOptions>(options);
+        return (new InProcessSubjectTokenValidator(monitor, NullLogger<InProcessSubjectTokenValidator>.Instance), creds);
+    }
+
+    private static string MintToken(SigningCredentials creds, string issuer, string sub)
+    {
+        var handler = new JsonWebTokenHandler();
+        return handler.CreateToken(new SecurityTokenDescriptor
+        {
+            Issuer = issuer,
+            Subject = new ClaimsIdentity(new[] { new Claim("sub", sub) }),
+            Expires = DateTime.UtcNow.AddMinutes(5),
+            SigningCredentials = creds,
+        });
+    }
+
+    [Theory]
+    [InlineData("https://auth.example/")]  // verbatim — how OpenIddict actually emits iss
+    [InlineData("https://auth.example")]   // trimmed — must also be accepted
+    public async Task ValidateAsync_AcceptsIssuer_WithOrWithoutTrailingSlash(string tokenIssuer)
+    {
+        var (validator, creds) = BuildValidator();
+        var token = MintToken(creds, tokenIssuer, "user-123");
+
+        var result = await validator.ValidateAsync(token);
+
+        result.IsValid.Should().BeTrue("the validator must accept both issuer forms");
+        result.Subject.Should().Be("user-123");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_RejectsToken_FromADifferentIssuer()
+    {
+        var (validator, creds) = BuildValidator();
+        var token = MintToken(creds, "https://evil.example/", "user-123");
+
+        var result = await validator.ValidateAsync(token);
+
+        result.IsValid.Should().BeFalse("a token from an unrelated issuer must still be rejected");
+    }
+
+    private sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public StaticOptionsMonitor(T value) => CurrentValue = value;
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}


### PR DESCRIPTION
RFC 8693 OBO exchange failed with `invalid_grant` for every request: `SubjectTokenValidator` set `ValidIssuer = options.Issuer.ToString().TrimEnd('/')` (`…/auth`), but OpenIddict emits `iss` verbatim from the configured issuer URI — WITH the trailing slash (`…/auth/`) — so it was an exact-match miss. Surfaced to users as a hard failure minting per-container proxy tokens for a code assistant. Fix: `ValidIssuers` with both forms. Regression test: 3 passing. Verified e2e — the real OBO exchange now succeeds. Part of conductor#1973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)