### PR TITLE
[SM.2.1] Session-revocation signal + GET /auth/session + transient-vs-permanent error codes

### DIFF
--- a/docs/SESSION-TRUTH-API.md
+++ b/docs/SESSION-TRUTH-API.md
@@ -1,0 +1,88 @@
+# Session-Truth API & Revocation Signal (SM.2.1)
+
+Tracks: rivoli-ai/conductor#2003 (feature #1976, epic #1975).
+
+## Why this exists — the #1861 root cause
+
+Before this change a native client (Conductor) could not distinguish:
+
+- a **transient** 5xx / proxy blip on the auth path (the correct response is **retry**), from
+- a **genuine** session revocation or invalid token (the correct response is **sign out**).
+
+Both collapsed into the same client-visible failure, so a momentary hiccup on
+launch signed the user out ("all-red on launch", conductor#1861). SM.2.1 makes
+the backend emit cleanly-separated, machine-readable signals so the client's
+SessionState reflector (Conductor SM.5) reflects backend truth instead of
+guessing from a timeout heuristic.
+
+## Authoritative channel
+
+andy-auth has **no NATS / event bus**. The revocation signal is therefore
+**HTTP-pull**, not an event:
+
+- `GET /auth/session` is the **authoritative reconciliation endpoint** — the
+  client polls it on launch (and on demand) to reconcile its durable
+  "I think I'm signed in" marker against backend truth.
+- **410 Gone** on this protected call is the explicit revocation *push* a client
+  observes the moment it next touches the endpoint.
+
+If/when andy-auth gains an event bus, an `auth.session.revoked` event can be
+added as an additive optimization; until then `GET /auth/session` + 410 is the
+contract.
+
+## `GET /auth/session`
+
+Bearer-authenticated (`Authorization: Bearer <access_token>`, OpenIddict
+validation scheme). Resolves the session truth for the token's `sub` (and the
+`session_id` claim when present).
+
+| Outcome | Status | Body | Meaning | Client action |
+|---|---|---|---|---|
+| Live session | `200` | `{ "authenticated": true, "subject": "...", "sessionId": "...", "expiresAt": "...", "revoked": false }` | The session is active. | stay signed in |
+| Revoked session | `410` | `{ "reason": "session_revoked", "description": "..." }` | The session was explicitly revoked (admin force-logout, account delete, /signout revoke-all, concurrent-limit, inactivity). **Permanent.** | **sign out** |
+| Invalid / deleted-account token | `401` | `{ "reason": "invalid_token", "description": "..." }` (+ `WWW-Authenticate: Bearer error="invalid_token"`) | Token is bound to an account that no longer exists or may no longer sign in. **Permanent.** | **sign out** |
+| No active session | `200` | `{ "authenticated": false, "revoked": false }` | Token valid but no live/revoked session (expired or none). A clean "not signed in" — **never a 500.** | sign out / re-auth |
+| Transient backend failure | `503` | `{ "reason": "temporarily_unavailable", "description": "..." }` (+ `Retry-After: 5`) | A dependency the auth service relies on is momentarily unavailable. **Transient.** | **retry** (honor `Retry-After`) |
+
+`SessionTruthDto` also carries `revokedAt` (the revocation watermark) so a client
+can reconcile a stale status read against a newer revocation: the higher
+`revokedAt` wins.
+
+## Error taxonomy → client action
+
+The single decision table the client keys off:
+
+| Code | Status | Class | Client action |
+|---|---|---|---|
+| `temporarily_unavailable` | `503` | **transient** | retry (honor `Retry-After`) |
+| `invalid_token` | `401` | **permanent** | sign out |
+| `session_revoked` | `410` | **permanent** | sign out |
+
+Invariant (the #1861 conflation guard): **a transient failure NEVER surfaces as
+`401`**. If `GET /auth/session` cannot resolve truth because of an
+upstream/dependency error, it returns `503 temporarily_unavailable`, not `401`
+and not a generic `500`. Verified by
+`SessionApiControllerTests.Transient503_DoesNotCollapseTo401`.
+
+## Revocation sources
+
+Any path that flips `UserSession.IsRevoked` is observable through `GET
+/auth/session` as `410` / `revoked:true`:
+
+- user-initiated `/signout` revoke-all (`SessionService.RevokeAllSessionsAsync`),
+- admin force-logout / account delete (`AdminController`, sets `DeletedAt` → 401),
+- concurrent-session-limit eviction, inactivity timeout, manual single-session revoke.
+
+## Downstream (Conductor SM.5 — not in this story)
+
+Conductor reads `GET /auth/session` + observes 410; it never decides revocation
+client-side (reflect-not-orchestrate). 503/circuit classify as *transient*;
+401/410 classify as *sustained*. This ungates conductor SM.5.2.
+
+## Tests
+
+- `SessionServiceTests` — `ResolveSessionTruthAsync` active / revoked / expired /
+  none, live-wins-over-revoked-sibling, explicit-session-id precedence, latest
+  revocation watermark.
+- `SessionApiControllerTests` — 200 / 410 / 401 (deleted, unknown, cannot-sign-in)
+  / 200-not-authenticated / **503-does-not-collapse-to-401**.

--- a/src/Andy.Auth.Server/Controllers/Api/SessionApiController.cs
+++ b/src/Andy.Auth.Server/Controllers/Api/SessionApiController.cs
@@ -1,0 +1,167 @@
+using Andy.Auth.Server.Data;
+using Andy.Auth.Server.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using OpenIddict.Abstractions;
+using OpenIddict.Validation.AspNetCore;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace Andy.Auth.Server.Controllers.Api;
+
+/// <summary>
+/// SM.2.1 (rivoli-ai/conductor#2003 · epic #1975) — machine-readable session
+/// truth + an explicit, unambiguous revocation signal for native clients.
+/// <para>
+/// Root cause this addresses (#1861 "all-red on launch"): today a transient 5xx
+/// and a genuine 401/revocation are <b>conflated</b>, so Conductor signs the
+/// user out on a momentary blip. This controller gives the client three cleanly
+/// separated outcomes — 200 (truth), 410 (revoked, permanent → sign out), and
+/// 401 (invalid token, permanent → sign out) — while transient failures are
+/// reported as 503 <c>temporarily_unavailable</c> (→ retry) and never collapse
+/// into a 401.
+/// </para>
+/// <para>
+/// Authoritative channel: andy-auth has <b>no NATS/event bus</b>, so the
+/// revocation signal is HTTP-pull. <c>GET /auth/session</c> is the authoritative
+/// reconciliation endpoint, and 410 on this protected call is the §7.4 explicit
+/// revocation push the SessionState reflector (SM.5) consumes instead of a
+/// timeout/5xx heuristic.
+/// </para>
+/// </summary>
+[ApiController]
+[Route("auth")]
+[Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme)]
+[Produces("application/json")]
+public class SessionApiController : ControllerBase
+{
+    private readonly SessionService _sessionService;
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly SignInManager<ApplicationUser> _signInManager;
+    private readonly ILogger<SessionApiController> _logger;
+
+    public SessionApiController(
+        SessionService sessionService,
+        UserManager<ApplicationUser> userManager,
+        SignInManager<ApplicationUser> signInManager,
+        ILogger<SessionApiController> logger)
+    {
+        _sessionService = sessionService;
+        _userManager = userManager;
+        _signInManager = signInManager;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the authoritative session truth for the bearer token.
+    /// <list type="bullet">
+    /// <item>200 <c>{authenticated:true, subject, sessionId, expiresAt, revoked:false}</c> — live session.</item>
+    /// <item>410 Gone <c>{reason:"session_revoked"}</c> — the session was explicitly revoked (permanent → sign out).</item>
+    /// <item>401 <c>{reason:"invalid_token"}</c> — token bound to an account that no longer exists / cannot sign in (permanent → sign out).</item>
+    /// <item>200 <c>{authenticated:false, revoked:false}</c> — no active session (expired/none); a clean "not signed in", never a 500.</item>
+    /// </list>
+    /// A momentary backend/dependency failure surfaces as 503
+    /// <c>temporarily_unavailable</c> (→ retry), distinct from the above.
+    /// </summary>
+    [HttpGet("session")]
+    [ProducesResponseType(typeof(SessionTruthDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(SessionErrorDto), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(SessionErrorDto), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(SessionErrorDto), StatusCodes.Status503ServiceUnavailable)]
+    public async Task<IActionResult> GetSession()
+    {
+        // OpenIddict's validation handler has already rejected structurally
+        // invalid/expired tokens with a 401 before we get here, so a missing
+        // subject means the token is well-formed but bound to nothing we trust.
+        var subject = User.GetClaim(Claims.Subject);
+        if (string.IsNullOrEmpty(subject))
+        {
+            return InvalidToken("The access token does not carry a subject.");
+        }
+
+        // The token's session id, when present, lets us answer about THIS exact
+        // session rather than the subject's most-recent one.
+        var sessionId = User.GetClaim("session_id");
+
+        try
+        {
+            // Account-existence check first: a token bound to a deleted account
+            // is a permanent 401 invalid_token, NOT a 5xx.
+            var user = await _userManager.FindByIdAsync(subject);
+            if (user == null || user.DeletedAt != null)
+            {
+                _logger.LogInformation(
+                    "[SM.2.1] /auth/session: token subject {Subject} maps to no live account.", subject);
+                return InvalidToken("The access token is bound to an account that no longer exists.");
+            }
+
+            if (!await _signInManager.CanSignInAsync(user))
+            {
+                _logger.LogInformation(
+                    "[SM.2.1] /auth/session: subject {Subject} is no longer allowed to sign in.", subject);
+                return InvalidToken("The account is no longer allowed to sign in.");
+            }
+
+            var truth = await _sessionService.ResolveSessionTruthAsync(subject, sessionId);
+
+            if (truth.IsRevoked)
+            {
+                // 410 Gone is the explicit, unambiguous revocation signal.
+                _logger.LogInformation(
+                    "[SM.2.1] /auth/session: session {SessionId} for {Subject} is revoked ({Reason}).",
+                    truth.SessionId, subject, truth.Reason ?? "session_revoked");
+                return Revoked(truth);
+            }
+
+            var dto = new SessionTruthDto
+            {
+                Authenticated = truth.IsAuthenticated,
+                Subject = truth.Subject ?? subject,
+                SessionId = truth.SessionId,
+                ExpiresAt = truth.ExpiresAt,
+                Revoked = false
+            };
+            return Ok(dto);
+        }
+        catch (Exception ex)
+        {
+            // A dependency failure (DB/upstream) is TRANSIENT. It must surface as
+            // 503 temporarily_unavailable so the client retries — it must NEVER
+            // collapse into a 401/sign-out (the #1861 conflation guard).
+            _logger.LogError(ex,
+                "[SM.2.1] /auth/session: transient failure resolving session for subject; returning 503.");
+            return TemporarilyUnavailable();
+        }
+    }
+
+    private ObjectResult InvalidToken(string description)
+    {
+        Response.Headers.WWWAuthenticate =
+            $"Bearer error=\"{SessionErrorCodes.InvalidToken}\", error_description=\"{description}\"";
+        return StatusCode(StatusCodes.Status401Unauthorized, new SessionErrorDto
+        {
+            Reason = SessionErrorCodes.InvalidToken,
+            Description = description
+        });
+    }
+
+    private ObjectResult Revoked(SessionTruth truth)
+    {
+        return StatusCode(StatusCodes.Status410Gone, new SessionErrorDto
+        {
+            Reason = SessionErrorCodes.SessionRevoked,
+            Description = truth.Reason
+        });
+    }
+
+    private ObjectResult TemporarilyUnavailable()
+    {
+        // Advise a modest retry; the client classifies 503 as transient.
+        Response.Headers.RetryAfter = "5";
+        return StatusCode(StatusCodes.Status503ServiceUnavailable, new SessionErrorDto
+        {
+            Reason = SessionErrorCodes.TemporarilyUnavailable,
+            Description = "The authentication service is momentarily unavailable. Retry shortly."
+        });
+    }
+}

--- a/src/Andy.Auth.Server/Controllers/Api/SessionTruthDto.cs
+++ b/src/Andy.Auth.Server/Controllers/Api/SessionTruthDto.cs
@@ -1,0 +1,101 @@
+using System.Text.Json.Serialization;
+
+namespace Andy.Auth.Server.Controllers.Api;
+
+/// <summary>
+/// Authoritative, machine-readable snapshot of the caller's session state,
+/// returned by <c>GET /auth/session</c>.
+/// <para>
+/// SM.2.1 (rivoli-ai/conductor#2003): this is the §7.2 "session-truth" the
+/// client reconciles its durable "I think I'm signed in" marker against on
+/// launch. A revoked session is reported with <see cref="Revoked"/> = true and
+/// <see cref="Authenticated"/> = false — NEVER a generic 500 — so the client can
+/// distinguish a real sign-out from a transient blip.
+/// </para>
+/// </summary>
+public class SessionTruthDto
+{
+    /// <summary>
+    /// True when the bearer token resolves to a live, non-revoked, non-expired
+    /// session for an account that still exists and is allowed to sign in.
+    /// </summary>
+    [JsonPropertyName("authenticated")]
+    public bool Authenticated { get; set; }
+
+    /// <summary>
+    /// The subject (user id) the token is bound to, when resolvable. Null when
+    /// the token maps to no known account (deleted / never existed).
+    /// </summary>
+    [JsonPropertyName("subject")]
+    public string? Subject { get; set; }
+
+    /// <summary>
+    /// The server-side session identifier this truth refers to, when one exists.
+    /// </summary>
+    [JsonPropertyName("sessionId")]
+    public string? SessionId { get; set; }
+
+    /// <summary>
+    /// When the session expires (UTC), when known.
+    /// </summary>
+    [JsonPropertyName("expiresAt")]
+    public DateTime? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// True when the session was explicitly revoked (admin force-logout, account
+    /// delete, /signout revoke-all, concurrent-session-limit, inactivity). A
+    /// revoked session is a PERMANENT sign-out signal — the client must not retry.
+    /// </summary>
+    [JsonPropertyName("revoked")]
+    public bool Revoked { get; set; }
+
+    /// <summary>
+    /// When the session was revoked (UTC), when applicable. Acts as the
+    /// monotonically-increasing watermark a client uses to reconcile a stale
+    /// status fetch against a newer revocation observation.
+    /// </summary>
+    [JsonPropertyName("revokedAt")]
+    public DateTime? RevokedAt { get; set; }
+
+    /// <summary>
+    /// Stable reason code when revoked, e.g. <c>session_revoked</c>. Mirrors the
+    /// 410-Gone body so a client gets the same code from either channel.
+    /// </summary>
+    [JsonPropertyName("reason")]
+    public string? Reason { get; set; }
+}
+
+/// <summary>
+/// SM.2.1 error taxonomy. These codes let a client cleanly separate a
+/// <b>transient</b> failure (retry) from a <b>permanent</b> one (sign out),
+/// closing the #1861 "all-red on launch" conflation where a 5xx blip was
+/// treated identically to a real 401/revocation.
+/// </summary>
+public static class SessionErrorCodes
+{
+    /// <summary>401 — the bearer token is invalid/expired or bound to an account
+    /// that no longer exists. PERMANENT → the client signs out.</summary>
+    public const string InvalidToken = "invalid_token";
+
+    /// <summary>410 — the session was explicitly revoked. PERMANENT → sign out.
+    /// This is the §7.4 explicit revocation signal SessionState consumes instead
+    /// of a timeout/5xx heuristic.</summary>
+    public const string SessionRevoked = "session_revoked";
+
+    /// <summary>503 — an upstream/dependency the auth service depends on is
+    /// momentarily unavailable. TRANSIENT → the client retries (honoring
+    /// Retry-After). MUST NOT be collapsed into a 401.</summary>
+    public const string TemporarilyUnavailable = "temporarily_unavailable";
+}
+
+/// <summary>
+/// Minimal typed error body returned alongside the 410 / 503 status codes.
+/// </summary>
+public class SessionErrorDto
+{
+    [JsonPropertyName("reason")]
+    public string Reason { get; set; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+}

--- a/src/Andy.Auth.Server/Services/SessionService.cs
+++ b/src/Andy.Auth.Server/Services/SessionService.cs
@@ -250,6 +250,119 @@ public class SessionService
     }
 
     /// <summary>
+    /// Resolves the authoritative session truth for a subject (and optional
+    /// session id), classifying it as active / revoked / expired / none.
+    /// <para>
+    /// SM.2.1 (rivoli-ai/conductor#2003): this is the single place that decides
+    /// whether a session is genuinely revoked (permanent → sign out) versus
+    /// merely live. It NEVER throws on "no session" — it returns a
+    /// <see cref="SessionTruth"/> with <c>Kind = None</c> so the caller can map
+    /// that to a clean 200/410 instead of a generic 500. Transient
+    /// infrastructure failures are surfaced by the caller as 503; they never
+    /// reach this method as a revocation.
+    /// </para>
+    /// <para>
+    /// Selection rule: prefer the explicitly-named <paramref name="sessionId"/>
+    /// when supplied; otherwise pick the most-recently-active session for the
+    /// subject. If the chosen/most-recent session is revoked we report Revoked,
+    /// using the highest <c>RevokedAt</c> as the watermark, so a client can
+    /// reconcile a stale status read against a newer revocation.
+    /// </para>
+    /// </summary>
+    public async Task<SessionTruth> ResolveSessionTruthAsync(string subject, string? sessionId = null)
+    {
+        var now = DateTime.UtcNow;
+
+        // Explicit session id wins when provided.
+        if (!string.IsNullOrEmpty(sessionId))
+        {
+            var named = await _dbContext.UserSessions
+                .AsNoTracking()
+                .FirstOrDefaultAsync(s => s.SessionId == sessionId && s.UserId == subject);
+
+            if (named == null)
+            {
+                return SessionTruth.None(subject);
+            }
+
+            return ClassifySession(named, now);
+        }
+
+        // No explicit session id: look at all of the subject's sessions.
+        var sessions = await _dbContext.UserSessions
+            .AsNoTracking()
+            .Where(s => s.UserId == subject)
+            .ToListAsync();
+
+        if (sessions.Count == 0)
+        {
+            return SessionTruth.None(subject);
+        }
+
+        // A live (non-revoked, non-expired) session wins — the subject is active.
+        var live = sessions
+            .Where(s => !s.IsRevoked && s.ExpiresAt > now)
+            .OrderByDescending(s => s.LastActivity)
+            .FirstOrDefault();
+
+        if (live != null)
+        {
+            return ClassifySession(live, now);
+        }
+
+        // No live session. If any session was explicitly revoked, that is the
+        // authoritative permanent signal; use the latest revocation as watermark.
+        var revoked = sessions
+            .Where(s => s.IsRevoked)
+            .OrderByDescending(s => s.RevokedAt ?? DateTime.MinValue)
+            .FirstOrDefault();
+
+        if (revoked != null)
+        {
+            return ClassifySession(revoked, now);
+        }
+
+        // All sessions are expired (not revoked) — treat as Expired, not None.
+        var latest = sessions.OrderByDescending(s => s.ExpiresAt).First();
+        return ClassifySession(latest, now);
+    }
+
+    private static SessionTruth ClassifySession(UserSession session, DateTime now)
+    {
+        if (session.IsRevoked)
+        {
+            return new SessionTruth
+            {
+                Kind = SessionTruthKind.Revoked,
+                Subject = session.UserId,
+                SessionId = session.SessionId,
+                ExpiresAt = session.ExpiresAt,
+                RevokedAt = session.RevokedAt,
+                Reason = session.RevocationReason
+            };
+        }
+
+        if (session.ExpiresAt <= now)
+        {
+            return new SessionTruth
+            {
+                Kind = SessionTruthKind.Expired,
+                Subject = session.UserId,
+                SessionId = session.SessionId,
+                ExpiresAt = session.ExpiresAt
+            };
+        }
+
+        return new SessionTruth
+        {
+            Kind = SessionTruthKind.Active,
+            Subject = session.UserId,
+            SessionId = session.SessionId,
+            ExpiresAt = session.ExpiresAt
+        };
+    }
+
+    /// <summary>
     /// Cleans up expired sessions from the database.
     /// </summary>
     public async Task<int> CleanupExpiredSessionsAsync()
@@ -357,4 +470,46 @@ public class SessionStats
     public int ActiveSessions { get; set; }
     public int RevokedSessions { get; set; }
     public int ExpiredSessions { get; set; }
+}
+
+/// <summary>
+/// Authoritative classification of a session, computed by
+/// <see cref="SessionService.ResolveSessionTruthAsync"/>. SM.2.1.
+/// </summary>
+public enum SessionTruthKind
+{
+    /// <summary>No session exists for the subject.</summary>
+    None,
+
+    /// <summary>A live, non-revoked, non-expired session exists.</summary>
+    Active,
+
+    /// <summary>The session lapsed past its expiry without an explicit revoke.</summary>
+    Expired,
+
+    /// <summary>The session was explicitly revoked (permanent sign-out signal).</summary>
+    Revoked
+}
+
+/// <summary>
+/// Backend session truth: the source of record the API surface maps onto the
+/// <c>GET /auth/session</c> response and the revocation taxonomy. SM.2.1.
+/// </summary>
+public class SessionTruth
+{
+    public SessionTruthKind Kind { get; init; }
+    public string? Subject { get; init; }
+    public string? SessionId { get; init; }
+    public DateTime? ExpiresAt { get; init; }
+    public DateTime? RevokedAt { get; init; }
+    public string? Reason { get; init; }
+
+    public bool IsAuthenticated => Kind == SessionTruthKind.Active;
+    public bool IsRevoked => Kind == SessionTruthKind.Revoked;
+
+    public static SessionTruth None(string? subject) => new()
+    {
+        Kind = SessionTruthKind.None,
+        Subject = subject
+    };
 }

--- a/tests/Andy.Auth.Server.Tests/Api/SessionApiControllerTests.cs
+++ b/tests/Andy.Auth.Server.Tests/Api/SessionApiControllerTests.cs
@@ -1,0 +1,237 @@
+using Andy.Auth.Server.Controllers.Api;
+using Andy.Auth.Server.Data;
+using Andy.Auth.Server.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Security.Claims;
+using Xunit;
+
+namespace Andy.Auth.Server.Tests.Api;
+
+/// <summary>
+/// SM.2.1 (rivoli-ai/conductor#2003) — proves the GET /auth/session endpoint
+/// cleanly separates the three permanent/transient outcomes that the #1861
+/// "all-red on launch" conflation used to merge:
+///   200 (truth) · 410 (revoked, permanent) · 401 (invalid token, permanent)
+///   · 503 (temporarily_unavailable, transient).
+/// The headline guard is <c>Transient503_DoesNotCollapseTo401</c>.
+/// </summary>
+public class SessionApiControllerTests : IDisposable
+{
+    private readonly ApplicationDbContext _context;
+    private readonly SessionService _sessionService;
+    private readonly Mock<UserManager<ApplicationUser>> _userManagerMock;
+    private readonly Mock<SignInManager<ApplicationUser>> _signInManagerMock;
+    private readonly Mock<ILogger<SessionApiController>> _loggerMock;
+
+    public SessionApiControllerTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        _context = new ApplicationDbContext(options);
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["SessionManagement:MaxConcurrentSessions"] = "5",
+            ["SessionManagement:SessionTimeout"] = "30.00:00:00",
+            ["SessionManagement:InactivityTimeout"] = "7.00:00:00"
+        }).Build();
+        _sessionService = new SessionService(_context, new Mock<ILogger<SessionService>>().Object, config);
+
+        _userManagerMock = MockUserManager();
+        _signInManagerMock = MockSignInManager(_userManagerMock.Object);
+        _loggerMock = new Mock<ILogger<SessionApiController>>();
+
+        // Default: account exists and can sign in.
+        _signInManagerMock
+            .Setup(s => s.CanSignInAsync(It.IsAny<ApplicationUser>()))
+            .ReturnsAsync(true);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    private SessionApiController BuildController(string? subject, string? sessionId = null)
+    {
+        var controller = new SessionApiController(
+            _sessionService, _userManagerMock.Object, _signInManagerMock.Object, _loggerMock.Object);
+
+        var claims = new List<Claim>();
+        if (subject != null) claims.Add(new Claim("sub", subject));
+        if (sessionId != null) claims.Add(new Claim("session_id", sessionId));
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "Bearer"));
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = principal }
+        };
+        return controller;
+    }
+
+    private async Task SeedSessionAsync(string userId, string sessionId,
+        bool revoked = false, DateTime? expiresAt = null, string? reason = null)
+    {
+        _context.UserSessions.Add(new UserSession
+        {
+            UserId = userId,
+            SessionId = sessionId,
+            CreatedAt = DateTime.UtcNow.AddHours(-1),
+            LastActivity = DateTime.UtcNow,
+            ExpiresAt = expiresAt ?? DateTime.UtcNow.AddDays(30),
+            IsRevoked = revoked,
+            RevokedAt = revoked ? DateTime.UtcNow : null,
+            RevocationReason = revoked ? (reason ?? "session_revoked") : null
+        });
+        await _context.SaveChangesAsync();
+    }
+
+    private void SetupExistingUser(string id)
+    {
+        _userManagerMock
+            .Setup(m => m.FindByIdAsync(id))
+            .ReturnsAsync(new ApplicationUser { Id = id, Email = $"{id}@test.com", UserName = $"{id}@test.com" });
+    }
+
+    [Fact]
+    public async Task GetSession_LiveSession_Returns200Authenticated()
+    {
+        SetupExistingUser("user-1");
+        await SeedSessionAsync("user-1", "sess-1", expiresAt: DateTime.UtcNow.AddDays(5));
+        var controller = BuildController("user-1");
+
+        var result = await controller.GetSession();
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<SessionTruthDto>().Subject;
+        dto.Authenticated.Should().BeTrue();
+        dto.Revoked.Should().BeFalse();
+        dto.Subject.Should().Be("user-1");
+        dto.SessionId.Should().Be("sess-1");
+        dto.ExpiresAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetSession_RevokedSession_Returns410SessionRevoked()
+    {
+        SetupExistingUser("user-2");
+        await SeedSessionAsync("user-2", "sess-2", revoked: true, reason: "Admin force-logout");
+        var controller = BuildController("user-2", "sess-2");
+
+        var result = await controller.GetSession();
+
+        var obj = result.Should().BeOfType<ObjectResult>().Subject;
+        obj.StatusCode.Should().Be(StatusCodes.Status410Gone);
+        var err = obj.Value.Should().BeOfType<SessionErrorDto>().Subject;
+        err.Reason.Should().Be(SessionErrorCodes.SessionRevoked);
+    }
+
+    [Fact]
+    public async Task GetSession_DeletedAccount_Returns401InvalidToken_NotGenericError()
+    {
+        _userManagerMock
+            .Setup(m => m.FindByIdAsync("ghost"))
+            .ReturnsAsync(new ApplicationUser { Id = "ghost", DeletedAt = DateTime.UtcNow });
+        var controller = BuildController("ghost");
+
+        var result = await controller.GetSession();
+
+        var obj = result.Should().BeOfType<ObjectResult>().Subject;
+        obj.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        obj.Value.Should().BeOfType<SessionErrorDto>()
+            .Subject.Reason.Should().Be(SessionErrorCodes.InvalidToken);
+    }
+
+    [Fact]
+    public async Task GetSession_UnknownSubject_Returns401InvalidToken()
+    {
+        _userManagerMock.Setup(m => m.FindByIdAsync("nobody")).ReturnsAsync((ApplicationUser?)null);
+        var controller = BuildController("nobody");
+
+        var result = await controller.GetSession();
+
+        result.Should().BeOfType<ObjectResult>()
+            .Subject.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetSession_CannotSignIn_Returns401InvalidToken()
+    {
+        SetupExistingUser("locked");
+        _signInManagerMock.Setup(s => s.CanSignInAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(false);
+        var controller = BuildController("locked");
+
+        var result = await controller.GetSession();
+
+        result.Should().BeOfType<ObjectResult>()
+            .Subject.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetSession_NoSession_Returns200NotAuthenticated_NeverGeneric500()
+    {
+        SetupExistingUser("user-3");
+        // No session seeded.
+        var controller = BuildController("user-3");
+
+        var result = await controller.GetSession();
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<SessionTruthDto>().Subject;
+        dto.Authenticated.Should().BeFalse();
+        dto.Revoked.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetSession_MissingSubjectClaim_Returns401()
+    {
+        var controller = BuildController(subject: null);
+
+        var result = await controller.GetSession();
+
+        result.Should().BeOfType<ObjectResult>()
+            .Subject.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task Transient503_DoesNotCollapseTo401()
+    {
+        // #1861 conflation guard: a transient backend failure (here, the data
+        // store throwing) MUST surface as 503 temporarily_unavailable so the
+        // client retries — it must NEVER come back as a 401 sign-out.
+        SetupExistingUser("user-4");
+        // Dispose the context so SessionService.ResolveSessionTruthAsync throws
+        // when it touches the store — a stand-in for an upstream/dependency blip.
+        _context.Dispose();
+        var controller = BuildController("user-4");
+
+        var result = await controller.GetSession();
+
+        var obj = result.Should().BeOfType<ObjectResult>().Subject;
+        obj.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        obj.StatusCode.Should().NotBe(StatusCodes.Status401Unauthorized);
+        obj.Value.Should().BeOfType<SessionErrorDto>()
+            .Subject.Reason.Should().Be(SessionErrorCodes.TemporarilyUnavailable);
+        controller.Response.Headers.RetryAfter.ToString().Should().Be("5");
+    }
+
+    private static Mock<UserManager<ApplicationUser>> MockUserManager()
+    {
+        var store = new Mock<IUserStore<ApplicationUser>>();
+        return new Mock<UserManager<ApplicationUser>>(
+            store.Object, null!, null!, null!, null!, null!, null!, null!, null!);
+    }
+
+    private static Mock<SignInManager<ApplicationUser>> MockSignInManager(UserManager<ApplicationUser> userManager)
+    {
+        var contextAccessor = new Mock<IHttpContextAccessor>();
+        var claimsFactory = new Mock<IUserClaimsPrincipalFactory<ApplicationUser>>();
+        return new Mock<SignInManager<ApplicationUser>>(
+            userManager, contextAccessor.Object, claimsFactory.Object, null!, null!, null!, null!);
+    }
+}

--- a/tests/Andy.Auth.Server.Tests/Services/SessionServiceTests.cs
+++ b/tests/Andy.Auth.Server.Tests/Services/SessionServiceTests.cs
@@ -715,4 +715,149 @@ public class SessionServiceTests : IDisposable
         serviceWithDefaults.SessionTimeout.Should().Be(TimeSpan.FromDays(30));
         serviceWithDefaults.InactivityTimeout.Should().Be(TimeSpan.FromDays(7));
     }
+
+    // ==================== ResolveSessionTruthAsync Tests (SM.2.1) ====================
+    // The single place that decides active / revoked / expired / none. Every
+    // branch is exercised so the 200/410 mapping downstream is well-grounded.
+
+    private async Task<UserSession> SeedSessionAsync(
+        string userId,
+        string sessionId,
+        bool revoked = false,
+        DateTime? expiresAt = null,
+        DateTime? revokedAt = null,
+        DateTime? lastActivity = null,
+        string? reason = null)
+    {
+        var session = new UserSession
+        {
+            UserId = userId,
+            SessionId = sessionId,
+            CreatedAt = DateTime.UtcNow.AddHours(-1),
+            LastActivity = lastActivity ?? DateTime.UtcNow,
+            ExpiresAt = expiresAt ?? DateTime.UtcNow.AddDays(30),
+            IsRevoked = revoked,
+            RevokedAt = revoked ? (revokedAt ?? DateTime.UtcNow) : null,
+            RevocationReason = revoked ? (reason ?? "Test revocation") : null
+        };
+        _context.UserSessions.Add(session);
+        await _context.SaveChangesAsync();
+        return session;
+    }
+
+    [Fact]
+    public async Task ResolveSessionTruth_LiveSession_ReturnsActive()
+    {
+        await SeedSessionAsync("user-1", "sess-live", expiresAt: DateTime.UtcNow.AddDays(5));
+
+        var truth = await _service.ResolveSessionTruthAsync("user-1");
+
+        truth.Kind.Should().Be(SessionTruthKind.Active);
+        truth.IsAuthenticated.Should().BeTrue();
+        truth.IsRevoked.Should().BeFalse();
+        truth.Subject.Should().Be("user-1");
+        truth.SessionId.Should().Be("sess-live");
+        truth.ExpiresAt.Should().BeCloseTo(DateTime.UtcNow.AddDays(5), TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task ResolveSessionTruth_RevokedSession_ReturnsRevoked()
+    {
+        var revokedAt = DateTime.UtcNow.AddMinutes(-2);
+        await SeedSessionAsync("user-2", "sess-revoked", revoked: true,
+            revokedAt: revokedAt, reason: "Admin force-logout");
+
+        var truth = await _service.ResolveSessionTruthAsync("user-2");
+
+        truth.Kind.Should().Be(SessionTruthKind.Revoked);
+        truth.IsRevoked.Should().BeTrue();
+        truth.IsAuthenticated.Should().BeFalse();
+        truth.RevokedAt.Should().BeCloseTo(revokedAt, TimeSpan.FromSeconds(5));
+        truth.Reason.Should().Be("Admin force-logout");
+    }
+
+    [Fact]
+    public async Task ResolveSessionTruth_ExpiredSession_ReturnsExpired()
+    {
+        await SeedSessionAsync("user-3", "sess-expired",
+            expiresAt: DateTime.UtcNow.AddDays(-1));
+
+        var truth = await _service.ResolveSessionTruthAsync("user-3");
+
+        truth.Kind.Should().Be(SessionTruthKind.Expired);
+        truth.IsAuthenticated.Should().BeFalse();
+        truth.IsRevoked.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ResolveSessionTruth_NoSession_ReturnsNone_NeverThrows()
+    {
+        var truth = await _service.ResolveSessionTruthAsync("user-nobody");
+
+        truth.Kind.Should().Be(SessionTruthKind.None);
+        truth.IsAuthenticated.Should().BeFalse();
+        truth.IsRevoked.Should().BeFalse();
+        truth.SessionId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveSessionTruth_LiveSessionWinsOverRevokedSibling()
+    {
+        // A revoked old session plus a live new one for the same subject:
+        // the subject is still authenticated.
+        await SeedSessionAsync("user-4", "sess-old", revoked: true,
+            revokedAt: DateTime.UtcNow.AddHours(-3));
+        await SeedSessionAsync("user-4", "sess-new",
+            expiresAt: DateTime.UtcNow.AddDays(10),
+            lastActivity: DateTime.UtcNow);
+
+        var truth = await _service.ResolveSessionTruthAsync("user-4");
+
+        truth.Kind.Should().Be(SessionTruthKind.Active);
+        truth.SessionId.Should().Be("sess-new");
+    }
+
+    [Fact]
+    public async Task ResolveSessionTruth_ExplicitSessionId_RevokedTakesPrecedenceOverLiveSibling()
+    {
+        // Asking about the specific revoked session must report Revoked even
+        // though the subject has another live session.
+        await SeedSessionAsync("user-5", "sess-revoked", revoked: true,
+            reason: "session_revoked");
+        await SeedSessionAsync("user-5", "sess-live",
+            expiresAt: DateTime.UtcNow.AddDays(10));
+
+        var truth = await _service.ResolveSessionTruthAsync("user-5", "sess-revoked");
+
+        truth.Kind.Should().Be(SessionTruthKind.Revoked);
+        truth.SessionId.Should().Be("sess-revoked");
+    }
+
+    [Fact]
+    public async Task ResolveSessionTruth_LatestRevocationIsWatermark()
+    {
+        // Two revoked sessions; the latest RevokedAt is the watermark a client
+        // reconciles a stale read against.
+        var older = DateTime.UtcNow.AddHours(-2);
+        var newer = DateTime.UtcNow.AddMinutes(-1);
+        await SeedSessionAsync("user-6", "sess-a", revoked: true, revokedAt: older);
+        await SeedSessionAsync("user-6", "sess-b", revoked: true, revokedAt: newer);
+
+        var truth = await _service.ResolveSessionTruthAsync("user-6");
+
+        truth.Kind.Should().Be(SessionTruthKind.Revoked);
+        truth.RevokedAt.Should().BeCloseTo(newer, TimeSpan.FromSeconds(5));
+        truth.SessionId.Should().Be("sess-b");
+    }
+
+    [Fact]
+    public async Task ResolveSessionTruth_ExplicitSessionId_NotFound_ReturnsNone()
+    {
+        await SeedSessionAsync("user-7", "sess-exists",
+            expiresAt: DateTime.UtcNow.AddDays(5));
+
+        var truth = await _service.ResolveSessionTruthAsync("user-7", "sess-missing");
+
+        truth.Kind.Should().Be(SessionTruthKind.None);
+    }
 }


### PR DESCRIPTION
## What & why

Implements **SM.2.1** (conductor#2003, feature #1976, epic #1975). Gives native clients (Conductor's `SessionState`, SM.5) the backend signals to distinguish a **transient blip** from a **genuine sign-out** — the root of the chronic **conductor#1861** "signed-out-on-launch / all-red" class, where a transient 5xx and a real 401/revocation were **conflated** so a momentary hiccup signed the user out.

### The real andy-auth model this fits
- Sessions are already first-class (`UserSession` with `IsRevoked`/`RevokedAt`/`RevocationReason`), managed by `SessionService`. Revocation already happens on logout, revoke-all, admin/account-delete, concurrent-limit, inactivity.
- **andy-auth has no NATS / event bus.** So the revocation signal is **HTTP-pull**, not an event. `GET /auth/session` is the authoritative reconciliation endpoint; **410 Gone** on that protected call is the explicit revocation push. (An `auth.session.revoked` event can be added additively later if a bus lands.)

## What was added (additive, backward-compatible)

**1. Explicit revocation signal + session-truth endpoint — `GET /auth/session`** (`Controllers/Api/SessionApiController.cs`, bearer-authed via the OpenIddict validation scheme). Returns `SessionTruthDto {authenticated, subject, sessionId, expiresAt, revoked, revokedAt, reason}`:

| Outcome | Status | Body |
|---|---|---|
| Live session | `200` | `{authenticated:true, subject, sessionId, expiresAt, revoked:false}` |
| **Revoked** | `410` | `{reason:"session_revoked"}` |
| Invalid / deleted-account token | `401` | `{reason:"invalid_token"}` (+ `WWW-Authenticate`) |
| No active session (expired/none) | `200` | `{authenticated:false, revoked:false}` — **never a 500** |
| **Transient** backend failure | `503` | `{reason:"temporarily_unavailable"}` (+ `Retry-After: 5`) |

`SessionService.ResolveSessionTruthAsync` is the single classifier (active/revoked/expired/none): prefers an explicit `session_id`, a live session wins over a revoked sibling, and the latest `revokedAt` is the reconciliation watermark.

**2. Error-code separation (transient vs permanent)** — `SessionErrorCodes`:

| Code | Status | Class | Client action |
|---|---|---|---|
| `temporarily_unavailable` | `503` | transient | **retry** (honor `Retry-After`) |
| `invalid_token` | `401` | permanent | **sign out** |
| `session_revoked` | `410` | permanent | **sign out** |

**Invariant (the #1861 guard):** a transient dependency failure surfaces as `503`, and **never** collapses into a `401` or a generic `500`.

**3. Docs** — `docs/SESSION-TRUTH-API.md`: endpoint, error-code→action table, revocation-channel section. (The story also lists conductor-side `docs/api-contracts/andy-auth.md`; that file lives in the conductor repo and is updated on the consumer side with SM.5.)

## Tests
- `SessionServiceTests` — 8 new `ResolveSessionTruthAsync` cases (active/revoked/expired/none, live-wins-over-revoked-sibling, explicit-session-id precedence, latest-revocation watermark, explicit-id-not-found).
- `SessionApiControllerTests` — 8 new: 200 live, 410 revoked, 401 (deleted / unknown / cannot-sign-in / missing-sub), 200 not-authenticated, and the headline **`Transient503_DoesNotCollapseTo401`** conflation guard.

## Evidence
- `dotnet build andy-auth.sln` → **Build succeeded** (0 errors).
- New tests: **16 passed, 0 failed**.
- Full `Andy.Auth.Server.Tests`: 582 passed, 3 skipped; the only 2 failures (`AuditLogIntegrationTests`, `OAuthIntegrationTests.ClientCredentialsFlow_WithInvalidSecret`) are **pre-existing and environmental** — they need a local Postgres at `127.0.0.1:7435` (Connection refused) and are unrelated to this change.

## Ungates
Conductor **SM.5.2** (conductor#1975 / #2003) — SessionState can now reflect backend truth (read `GET /auth/session` + observe 410) instead of guessing from a timeout/5xx heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)