### PR TITLE
Add anonymous /health liveness endpoint (parity with sibling services) (#116)

### DIFF
--- a/src/Andy.Auth.Server/Program.cs
+++ b/src/Andy.Auth.Server/Program.cs
@@ -537,6 +537,23 @@ app.UseAuthentication();
 app.UseSessionTracking();
 app.UseAuthorization();
 
+// --- Health check ---
+// Anonymous, dependency-free liveness probe for parity with sibling andy-*
+// services (rivoli-ai/andy-auth#116). Conductor's UnifiedProxy probes this via
+// 9100/auth/health (the /auth prefix is stripped before it reaches us), so we
+// map /health — NOT /auth/health. Must answer without a token and must not
+// touch the DB, OpenIddict, or the session store. /health is already in the
+// SessionTrackingMiddleware bypass set, so no session cookie is issued.
+app.MapGet("/health", () => Results.Ok(new
+{
+    status = "healthy",
+    service = "andy-auth",
+    timestamp = DateTime.UtcNow
+}))
+    .AllowAnonymous()
+    .WithName("HealthCheck")
+    .ExcludeFromDescription();
+
 // Static test endpoint to debug Safari crash (dev only)
 if (app.Environment.IsDevelopment())
 {

--- a/tests/Andy.Auth.Server.Tests/HealthCheckTests.cs
+++ b/tests/Andy.Auth.Server.Tests/HealthCheckTests.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Andy.Auth.Server.Tests;
+
+/// <summary>
+/// Integration tests for the anonymous /health liveness endpoint
+/// (rivoli-ai/andy-auth#116). The endpoint exists for parity with sibling
+/// andy-* services so Conductor's UnifiedProxy can probe 9100/auth/health
+/// (the /auth prefix is stripped before it reaches andy-auth) uniformly with
+/// every other service. Liveness must be anonymous and must not touch the DB,
+/// OpenIddict, or the session store.
+/// </summary>
+public class HealthCheckTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly CustomWebApplicationFactory _factory;
+
+    public HealthCheckTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Health_ReturnsOk()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/health");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Health_BodyHasHealthyStatusAndParseableTimestamp()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/health");
+        var json = await response.Content.ReadAsStringAsync();
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("healthy", root.GetProperty("status").GetString());
+        Assert.Equal("andy-auth", root.GetProperty("service").GetString());
+
+        var timestamp = root.GetProperty("timestamp").GetString();
+        Assert.True(
+            DateTime.TryParse(timestamp, out _),
+            $"timestamp '{timestamp}' should be parseable");
+    }
+
+    [Fact]
+    public async Task Health_SucceedsWithoutAuthorizationHeader()
+    {
+        // The endpoint sits behind UseAuthentication()/UseAuthorization() and
+        // must answer without any credentials (the Conductor probe sends none).
+        using var client = _factory.CreateClient();
+        Assert.Null(client.DefaultRequestHeaders.Authorization);
+
+        var response = await client.GetAsync("/health");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Health_DoesNotIssueSessionCookie()
+    {
+        // /health is in the SessionTrackingMiddleware bypass set
+        // (SessionTrackingMiddleware.cs:21). Guard that bypass entry against
+        // regression: the probe must not create or mutate a session, so no
+        // Set-Cookie should be emitted.
+        // https BaseAddress avoids UseHttpsRedirection's 307 (TestServer fakes
+        // both schemes); without it a non-redirecting client never reaches the
+        // endpoint. Same pattern as CrossModeDiscoveryTests.
+        using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("https://localhost/")
+        });
+
+        var response = await client.GetAsync("/health");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.False(
+            response.Headers.Contains("Set-Cookie"),
+            "/health must not issue a session cookie");
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_ChallengesAnonymousRequest()
+    {
+        // Negative control: proves the test host has auth enabled, so the
+        // /health tests above pass because of .AllowAnonymous() and not because
+        // authentication is globally off. SessionController is
+        // [Authorize(Identity.Application)], so an anonymous request is
+        // challenged (302 redirect to the login page) rather than served 200 —
+        // and the cookie-challenge path touches neither the DB nor OpenIddict,
+        // so it is reliable even when the test host has no database.
+        using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("https://localhost/")
+        });
+
+        var response = await client.GetAsync("/Session");
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Contains("/Account/Login", response.Headers.Location?.OriginalString ?? "");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #116. `andy-auth` was the only bundled service returning `404` on `GET /health`, which broke Conductor's uniform `9100/<svc>/health` liveness probe and forced a special-case fallback to OIDC discovery.

- Map an anonymous, dependency-free `/health` endpoint after `UseAuthorization()`, matching the sibling andy-* pattern (andy-issues `Program.cs`).
- Maps `/health` (not `/auth/health` — the UnifiedProxy strips the `/auth` prefix), `.AllowAnonymous()`, touches no DB/OpenIddict/session store.
- `/health` was already in `SessionTrackingMiddleware`'s bypass set; this test suite now guards that entry against regression.

## Tests

New `HealthCheckTests` (5 tests, all green):
1. `GET /health` → `200`
2. body has `status == "healthy"`, `service`, parseable `timestamp`
3. succeeds with no `Authorization` header (proves `AllowAnonymous`)
4. issues no `Set-Cookie` session cookie (guards the middleware bypass entry)
5. negative control — a protected endpoint still challenges anonymous requests, proving auth isn't globally off in the test host

## Notes

- Used the cookie-protected `/Session` route (redirects to login) as the negative control instead of the issue's optional `/connect/userinfo` suggestion, since the latter hits the DB and returns `500` in the DB-less test host.
- The remaining acceptance items (`9100/auth/health` through the proxy, global health bar) are end-to-end checks against a running Conductor fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)